### PR TITLE
Add detailed OCR helper and supporting tests

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,5 @@
 """Utility modules for the handwriting OCR project."""
+
+from .ocr import ocr_detailed, ocr_image
+
+__all__ = ["ocr_detailed", "ocr_image"]

--- a/src/ocr.py
+++ b/src/ocr.py
@@ -1,4 +1,9 @@
-"""OCR utilities built on top of pytesseract."""
+"""OCR utilities built on top of pytesseract.
+
+The module exposes :func:`ocr_detailed`, which yields per-token metadata such
+as confidences and bounding boxes, and :func:`ocr_image`, a convenience wrapper
+that collapses those tokens into plain text.
+"""
 from __future__ import annotations
 
 import logging
@@ -6,8 +11,10 @@ from pathlib import Path
 from typing import Optional, Union
 
 import numpy as np
+import pandas as pd
 from PIL import Image
 import pytesseract
+from pytesseract import Output
 
 from .preprocessing import preprocess_image
 
@@ -52,6 +59,64 @@ def ocr_image(
         The recognised text.
     """
 
+    detailed = ocr_detailed(
+        image_path,
+        model_path=model_path,
+        tessdata_dir=tessdata_dir,
+        psm=psm,
+    )
+
+    if detailed.empty:
+        return ""
+
+    tokens = detailed.copy()
+    tokens["text"] = tokens["text"].fillna("").astype(str).str.strip()
+    tokens = tokens[tokens["text"].ne("")]
+    if tokens.empty:
+        return ""
+
+    sort_columns = ["page_num", "block_num", "par_num", "line_num", "word_num"]
+    tokens = tokens.sort_values(sort_columns)
+    grouped = tokens.groupby(sort_columns[:-1], sort=True)["text"].apply(
+        lambda words: " ".join(words)
+    )
+    text = "\n".join(grouped.tolist())
+    logging.debug("Recognised text: %s", text.strip())
+    return text.strip()
+
+
+def ocr_detailed(
+    image_path: PathLike,
+    *,
+    model_path: Optional[PathLike] = None,
+    tessdata_dir: Optional[PathLike] = None,
+    psm: int = 6,
+) -> pd.DataFrame:
+    """Run OCR on ``image_path`` and return detailed token metadata.
+
+    The helper centralises Tesseract configuration so both structured metadata
+    and plain-text recognition share the same setup.
+
+    Parameters
+    ----------
+    image_path:
+        The image to recognise.
+    model_path:
+        Optional path to a ``.traineddata`` model created by :func:`train_model`.
+        The file should live inside the ``models/`` directory by default.
+    tessdata_dir:
+        Override the tessdata directory that contains the trained model files.
+        If left as ``None`` the directory that holds ``model_path`` will be used.
+    psm:
+        Page segmentation mode passed to Tesseract. The default (6) works for
+        uniform lines of text.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A dataframe containing per-token text, confidence, and bounding boxes.
+    """
+
     image_path = Path(image_path)
     logging.info("Running OCR on %s", image_path)
 
@@ -71,7 +136,27 @@ def ocr_image(
         logging.debug("Using custom model %s (lang=%s)", model_path, lang)
 
     config = " ".join(config_parts)
+    data = pytesseract.image_to_data(
+        pil_image, lang=lang, config=config, output_type=Output.DICT
+    )
 
-    text = pytesseract.image_to_string(pil_image, lang=lang, config=config)
-    logging.debug("Recognised text: %s", text.strip())
-    return text.strip()
+    detailed = pd.DataFrame(data)
+    if detailed.empty:
+        return detailed
+
+    detailed = detailed[detailed.get("level") == 5].copy()
+    if detailed.empty:
+        return detailed
+
+    detailed.rename(columns={"conf": "confidence"}, inplace=True)
+    detailed["confidence"] = pd.to_numeric(detailed["confidence"], errors="coerce")
+    for column in ["left", "top", "width", "height", "page_num", "block_num", "par_num", "line_num", "word_num"]:
+        if column in detailed.columns:
+            detailed[column] = pd.to_numeric(detailed[column], errors="coerce")
+
+    if {"left", "width"}.issubset(detailed.columns):
+        detailed["right"] = detailed["left"] + detailed["width"]
+    if {"top", "height"}.issubset(detailed.columns):
+        detailed["bottom"] = detailed["top"] + detailed["height"]
+
+    return detailed.reset_index(drop=True)

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+import sys
+import types
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+if "cv2" not in sys.modules:  # pragma: no cover - shim when OpenCV is unavailable.
+    sys.modules["cv2"] = types.SimpleNamespace()
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import src.ocr as ocr  # noqa: E402  (import after path adjustment)
+
+
+def _dummy_data_dict():
+    return {
+        "level": [5, 5],
+        "page_num": [1, 1],
+        "block_num": [1, 1],
+        "par_num": [1, 1],
+        "line_num": [1, 1],
+        "word_num": [1, 2],
+        "left": [10, 50],
+        "top": [20, 20],
+        "width": [30, 40],
+        "height": [10, 12],
+        "conf": ["95", "85"],
+        "text": ["Hello", "world"],
+    }
+
+
+def test_ocr_detailed_returns_confidence(tmp_path):
+    fake_array = np.zeros((10, 10), dtype=np.uint8)
+
+    with (
+        patch.object(ocr, "preprocess_image", return_value=fake_array) as preprocess_mock,
+        patch.object(ocr.pytesseract, "image_to_data", return_value=_dummy_data_dict()) as data_mock,
+    ):
+        detailed = ocr.ocr_detailed(tmp_path / "image.png")
+
+    preprocess_mock.assert_called_once()
+    data_mock.assert_called_once()
+
+    assert not detailed.empty
+    assert "confidence" in detailed
+    assert detailed.loc[0, "confidence"] == 95
+    assert {"left", "top", "width", "height"}.issubset(detailed.columns)
+
+
+def test_ocr_image_reassembles_text():
+    dataframe = pd.DataFrame(
+        {
+            "page_num": [1, 1],
+            "block_num": [1, 1],
+            "par_num": [1, 1],
+            "line_num": [1, 2],
+            "word_num": [1, 1],
+            "text": ["Hello", "world"],
+            "confidence": [90.0, 80.0],
+            "left": [0, 0],
+            "top": [0, 10],
+            "width": [10, 10],
+            "height": [5, 5],
+        }
+    )
+
+    with patch.object(ocr, "ocr_detailed", return_value=dataframe) as detailed_mock:
+        text = ocr.ocr_image("dummy.png", psm=4)
+
+    detailed_mock.assert_called_once_with(
+        "dummy.png", model_path=None, tessdata_dir=None, psm=4
+    )
+    assert text == "Hello\nworld"


### PR DESCRIPTION
## Summary
- add an `ocr_detailed` helper that returns per-token metadata and drive `ocr_image` from it
- expose the new helper via the package namespace and expand the OCR module documentation
- exercise the helper with unit tests that check confidence output and text reconstruction

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dff2cc0c48832ba72f1e106fb358ec