### PR TITLE
Handle EXIF orientation in annotation UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Key behaviour:
   extensions.
 * Confirming an entry copies the image into `--train-dir` with the confirmed
   label embedded in the file name, ready for `train_model`.
+* Images are automatically rotated based on their embedded EXIF orientation so
+  the preview and saved snippet share the correct layout.
 * Use **Skip** to omit an image or **Unsure** to log it without saving a copy.
   The optional `--output-log` CSV records every action.
 

--- a/src/annotation.py
+++ b/src/annotation.py
@@ -9,7 +9,13 @@ from typing import Iterable, List, Optional
 import tkinter as tk
 from tkinter import messagebox
 
-from PIL import Image, ImageTk
+from PIL import Image, ImageOps, ImageTk
+
+
+def _prepare_image(image: Image.Image) -> Image.Image:
+    """Return an image with EXIF orientation applied."""
+
+    return ImageOps.exif_transpose(image)
 
 
 @dataclass
@@ -151,6 +157,7 @@ class AnnotationApp:
     def _display_image(self, path: Path) -> None:
         try:
             with Image.open(path) as image:
+                image = _prepare_image(image)
                 image = image.convert("RGBA")
                 image.thumbnail(self.MAX_SIZE, Image.LANCZOS)
                 photo = ImageTk.PhotoImage(image)
@@ -186,6 +193,7 @@ class AnnotationApp:
             counter += 1
 
         with Image.open(path) as image:
+            image = _prepare_image(image)
             if image.mode not in {"RGB", "L"}:
                 image = image.convert("RGB")
             image.save(candidate)

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -1,0 +1,23 @@
+"""Tests for the annotation helpers."""
+
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from annotation import _prepare_image
+
+
+def test_prepare_image_applies_exif_orientation():
+    """Images should be rotated according to their EXIF orientation."""
+
+    image = Image.new("RGB", (10, 20), "red")
+    exif = image.getexif()
+    exif[274] = 6  # Orientation tag: rotate 270 degrees
+    image.info["exif"] = exif.tobytes()
+
+    prepared = _prepare_image(image)
+
+    assert prepared.size == (20, 10)


### PR DESCRIPTION
## Summary
- add a helper that applies EXIF orientation data before annotation previews and saves
- ensure the README documents the automatic rotation behaviour
- add a unit test covering the orientation helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e00a08b098832bb994408158b08456