### PR TITLE
Fix annotation image save context manager usage

### DIFF
--- a/src/annotation.py
+++ b/src/annotation.py
@@ -395,12 +395,10 @@ class AnnotationApp:
             counter += 1
 
         with Image.open(path) as image:
-            image = _prepare_image(image)
-            if image.mode not in {"RGB", "L"}:
-                image = image.convert("RGB")
-            image.save(candidate)
-        finally:
-            image.close()
+            prepared_image = _prepare_image(image)
+            if prepared_image.mode not in {"RGB", "L"}:
+                prepared_image = prepared_image.convert("RGB")
+            prepared_image.save(candidate)
         return candidate
 
     def _append_log(self, source: Path, label: str, status: str, saved_path: Optional[Path]) -> None:


### PR DESCRIPTION
## Summary
- fix the annotation image saving logic to use the context manager without an extraneous finally clause
- preserve EXIF-orientation and mode conversion before persisting the processed image

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e00f4ef500832b87ef60ea6b077c2f