### PR TITLE
Fix annotation image handling and pytesseract import

### DIFF
--- a/src/annotation.py
+++ b/src/annotation.py
@@ -11,6 +11,8 @@ import tkinter as tk
 from tkinter import messagebox
 
 from PIL import Image, ImageOps, ImageTk
+import pytesseract
+from pytesseract import Output
 
 
 def _prepare_image(image: Image.Image) -> Image.Image:
@@ -395,12 +397,10 @@ class AnnotationApp:
             counter += 1
 
         with Image.open(path) as image:
-            image = _prepare_image(image)
-            if image.mode not in {"RGB", "L"}:
-                image = image.convert("RGB")
-            image.save(candidate)
-        finally:
-            image.close()
+            prepared_image = _prepare_image(image)
+            if prepared_image.mode not in {"RGB", "L"}:
+                prepared_image = prepared_image.convert("RGB")
+            prepared_image.save(candidate)
         return candidate
 
     def _append_log(self, source: Path, label: str, status: str, saved_path: Optional[Path]) -> None:


### PR DESCRIPTION
## Summary
- fix the annotation image saving logic to use the context manager without an extraneous finally clause
- preserve EXIF-orientation and mode conversion before persisting the processed image
- import pytesseract and its Output helper so OCR token extraction works at runtime

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e00f4ef500832b87ef60ea6b077c2f