### PR TITLE
Clamp annotation slugs and handle save errors

### DIFF
--- a/src/annotation.py
+++ b/src/annotation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import csv
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Optional, Sequence, Tuple
@@ -145,7 +146,11 @@ class AnnotationApp:
             return
 
         item = self.items[self.index]
-        saved_path = self._save_annotation(item.path, label)
+        try:
+            saved_path = self._save_annotation(item.path, label)
+        except OSError as exc:
+            messagebox.showerror("Save failed", f"Could not save annotation: {exc}")
+            return
         self._append_log(item.path, label, "confirmed", saved_path)
         self.status_var.set(f"Saved to {saved_path.name}")
         self._advance()
@@ -431,7 +436,10 @@ class AnnotationApp:
 
     def _slugify(self, value: str) -> str:
         cleaned = [c if c.isalnum() else "-" for c in value.strip().lower()]
-        slug = "".join(cleaned).strip("-")
+        slug = "".join(cleaned)
+        slug = re.sub("-+", "-", slug).strip("-")
+        if len(slug) > 60:
+            slug = slug[:60].rstrip("-")
         return slug or "sample"
 
 

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -7,7 +7,8 @@ from PIL import Image
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from annotation import _prepare_image
+import annotation
+from annotation import AnnotationApp, AnnotationItem, _prepare_image
 
 
 def test_prepare_image_applies_exif_orientation():
@@ -21,3 +22,70 @@ def test_prepare_image_applies_exif_orientation():
     prepared = _prepare_image(image)
 
     assert prepared.size == (20, 10)
+
+
+def test_slugify_truncates_and_collapses_hyphens():
+    """The slug should be limited in length and collapse repeated separators."""
+
+    value = "abcde " * 20  # produces a string well over 60 characters once slugified
+    expected = "-".join(["abcde"] * 20)
+    app = AnnotationApp.__new__(AnnotationApp)
+
+    slug = AnnotationApp._slugify(app, value)
+
+    assert slug == expected[:60].rstrip("-")
+    assert len(slug) <= 60
+    assert "--" not in slug
+
+
+def test_confirm_handles_oserror(monkeypatch):
+    """Failures during saving should surface to the user without advancing."""
+
+    app = AnnotationApp.__new__(AnnotationApp)
+    app.items = [AnnotationItem(Path("image.png"))]
+    app.index = 0
+    app._get_transcription_text = lambda: "transcription"
+
+    def failing_save(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    app._save_annotation = failing_save
+
+    append_called = False
+
+    def append_log(*_args, **_kwargs):
+        nonlocal append_called
+        append_called = True
+
+    app._append_log = append_log
+
+    advanced = False
+
+    def advance():
+        nonlocal advanced
+        advanced = True
+
+    app._advance = advance
+
+    class DummyVar:
+        def __init__(self):
+            self.value = None
+
+        def set(self, value):
+            self.value = value
+
+    app.status_var = DummyVar()
+
+    errors: list[tuple[str, str]] = []
+
+    def fake_showerror(title, message):
+        errors.append((title, message))
+
+    monkeypatch.setattr(annotation.messagebox, "showerror", fake_showerror)
+
+    AnnotationApp.confirm(app)
+
+    assert errors and "disk full" in errors[0][1]
+    assert not append_called
+    assert not advanced
+    assert app.status_var.value is None


### PR DESCRIPTION
## Summary
- clamp generated annotation filenames to 60 characters and collapse repeated hyphens
- surface saving failures in the confirmation flow without advancing the queue
- cover slug truncation and save error handling with regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e025d1dcd8832b8a686bf42361530e