### PR TITLE
Improve annotation overlay interactions

### DIFF
--- a/src/annotation.py
+++ b/src/annotation.py
@@ -6,7 +6,7 @@ import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Optional, Sequence, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 import tkinter as tk
 from tkinter import messagebox
@@ -14,6 +14,26 @@ from tkinter import messagebox
 from PIL import Image, ImageOps, ImageTk
 import pytesseract
 from pytesseract import Output
+
+
+TokenOrder = Tuple[int, int, int, int, int]
+LineKey = Tuple[int, int, int]
+
+
+@dataclass
+class OverlayBox:
+    """Track an editable overlay rectangle and its associated widgets."""
+
+    rect_id: int
+    entry: tk.Entry
+    window_id: int
+    token: OcrToken
+    is_manual: bool = False
+    selected: bool = False
+
+
+CONTROL_MASK = 0x0004
+SHIFT_MASK = 0x0001
 
 
 def _prepare_image(image: Image.Image) -> Image.Image:
@@ -77,10 +97,21 @@ class AnnotationApp:
         self.current_photo: Optional[ImageTk.PhotoImage] = None
         self.canvas_image_id: Optional[int] = None
         self.overlay_entries: list[tk.Entry] = []
+        self.overlay_items: list[OverlayBox] = []
+        self.rect_to_overlay: Dict[int, OverlayBox] = {}
+        self.selected_rects: Set[int] = set()
         self.current_tokens: list[OcrToken] = []
+        self.display_scale: Tuple[float, float] = (1.0, 1.0)
+        self.manual_token_counter = 0
+        self._drag_start: Optional[Tuple[float, float]] = None
+        self._active_temp_rect: Optional[int] = None
+        self._marquee_rect: Optional[int] = None
+        self._modifier_drag = False
+        self._pressed_overlay: Optional[OverlayBox] = None
 
         self.filename_var = tk.StringVar()
         self.status_var = tk.StringVar()
+        self.mode_var = tk.StringVar(value="select")
         self._user_modified_transcription = False
         self._setting_transcription = False
 
@@ -102,6 +133,21 @@ class AnnotationApp:
 
         self.canvas = tk.Canvas(container, bd=1, relief="sunken", highlightthickness=0)
         self.canvas.pack(fill="both", expand=True, pady=12)
+        self.canvas.bind("<ButtonPress-1>", self._on_canvas_button_press)
+        self.canvas.bind("<B1-Motion>", self._on_canvas_drag)
+        self.canvas.bind("<ButtonRelease-1>", self._on_canvas_release)
+
+        toolbar = tk.Frame(container)
+        toolbar.pack(anchor="w", pady=(0, 8))
+
+        select_btn = tk.Radiobutton(toolbar, text="Select", variable=self.mode_var, value="select")
+        select_btn.pack(side="left")
+        draw_btn = tk.Radiobutton(toolbar, text="Draw", variable=self.mode_var, value="draw")
+        draw_btn.pack(side="left", padx=(8, 0))
+
+        delete_btn = tk.Button(toolbar, text="Delete Selected", command=self._delete_selected, state=tk.DISABLED)
+        delete_btn.pack(side="left", padx=(16, 0))
+        self.delete_button = delete_btn
 
         entry_frame = tk.Frame(container)
         entry_frame.pack(fill="x", pady=(0, 8))
@@ -136,6 +182,8 @@ class AnnotationApp:
 
         self.master.bind("<Escape>", self._on_exit)
         self.master.bind("<Alt-Left>", self._on_back)
+        self.master.bind("<Delete>", self._on_delete_key)
+        self.master.bind("<BackSpace>", self._on_delete_key)
         self.master.protocol("WM_DELETE_WINDOW", self._on_exit)
 
     # ------------------------------------------------------------------
@@ -150,6 +198,10 @@ class AnnotationApp:
     def _on_exit(self, event: Optional[tk.Event] = None) -> None:
         if messagebox.askokcancel("Quit", "Abort annotation and close the window?"):
             self.master.destroy()
+
+    def _on_delete_key(self, event: Optional[tk.Event]) -> str:
+        self._delete_selected()
+        return "break"
 
     def confirm(self) -> None:
         label = self._get_transcription_text()
@@ -289,15 +341,22 @@ class AnnotationApp:
         display_image.thumbnail(self.MAX_SIZE, Image.LANCZOS)
         scale_x = display_image.width / base_width if base_width else 1.0
         scale_y = display_image.height / base_height if base_height else 1.0
+        self.display_scale = (scale_x, scale_y)
+        self.manual_token_counter = 0
 
         photo = ImageTk.PhotoImage(display_image)
         self.current_photo = photo
 
         self._clear_overlay_entries()
         self.canvas.delete("all")
-        self.current_tokens = list(tokens)
+        self.overlay_items = []
+        self.overlay_entries = []
+        self.rect_to_overlay = {}
+        self.selected_rects.clear()
+        self.current_tokens = []
         self.canvas_image_id = self.canvas.create_image(0, 0, image=photo, anchor="nw")
         self.canvas.config(scrollregion=(0, 0, display_image.width, display_image.height))
+        self.canvas.focus_set()
 
         for token in tokens:
             if not token.text:
@@ -307,39 +366,361 @@ class AnnotationApp:
             disp_top = top * scale_y
             disp_right = right * scale_x
             disp_bottom = bottom * scale_y
-
-            rect = self.canvas.create_rectangle(
+            overlay = self._create_overlay_widget(
+                token,
                 disp_left,
                 disp_top,
                 disp_right,
                 disp_bottom,
-                outline="#2F80ED",
-                width=1,
-                tags="overlay",
+                preset_text=token.text,
+                is_manual=False,
             )
-            self.canvas.tag_raise(rect)
-
-            entry_width = max(4, int((disp_right - disp_left) / 8))
-            entry = tk.Entry(self.canvas, width=entry_width)
-            entry.insert(0, token.text)
-            entry.bind("<KeyRelease>", self._on_overlay_modified)
-
-            desired_top = disp_top - 24
-            if desired_top < 0:
-                desired_top = disp_top
-
-            window_id = self.canvas.create_window(
-                disp_left,
-                desired_top,
-                anchor="nw",
-                window=entry,
-                tags="overlay",
-            )
-            self.canvas.tag_raise(window_id)
-            self.overlay_entries.append(entry)
+            self.current_tokens.append(overlay.token)
 
         if tokens:
             self._update_combined_transcription()
+
+    def _create_overlay_widget(
+        self,
+        token: OcrToken,
+        disp_left: float,
+        disp_top: float,
+        disp_right: float,
+        disp_bottom: float,
+        *,
+        preset_text: str = "",
+        is_manual: bool,
+    ) -> OverlayBox:
+        rect = self.canvas.create_rectangle(
+            disp_left,
+            disp_top,
+            disp_right,
+            disp_bottom,
+            outline="#2F80ED",
+            width=1,
+            tags="overlay",
+        )
+        self.canvas.tag_raise(rect)
+
+        entry_width = max(4, int(abs(disp_right - disp_left) / 8))
+        entry = tk.Entry(self.canvas, width=entry_width)
+        if preset_text:
+            entry.insert(0, preset_text)
+        entry.bind("<KeyRelease>", self._on_overlay_modified)
+
+        desired_top = disp_top - 24
+        if desired_top < 0:
+            desired_top = disp_top
+
+        window_id = self.canvas.create_window(
+            disp_left,
+            desired_top,
+            anchor="nw",
+            window=entry,
+            tags="overlay",
+        )
+        self.canvas.tag_raise(window_id)
+
+        overlay = OverlayBox(
+            rect_id=rect,
+            entry=entry,
+            window_id=window_id,
+            token=token,
+            is_manual=is_manual,
+        )
+        self.overlay_items.append(overlay)
+        self.overlay_entries.append(entry)
+        self.rect_to_overlay[rect] = overlay
+        self._update_tokens_snapshot()
+        return overlay
+
+    def _display_to_base_bbox(self, bbox: Tuple[float, float, float, float]) -> Tuple[int, int, int, int]:
+        scale_x, scale_y = self.display_scale
+        left, top, right, bottom = bbox
+        inv_x = 1.0 / scale_x if scale_x else 1.0
+        inv_y = 1.0 / scale_y if scale_y else 1.0
+        return (
+            int(round(left * inv_x)),
+            int(round(top * inv_y)),
+            int(round(right * inv_x)),
+            int(round(bottom * inv_y)),
+        )
+
+    def _next_manual_keys(self) -> Tuple[TokenOrder, LineKey]:
+        self.manual_token_counter += 1
+        index = self.manual_token_counter
+        order_key: TokenOrder = (9999, 0, 0, index, index)
+        line_key: LineKey = (9999, 0, index)
+        return order_key, line_key
+
+    def _create_manual_overlay(self, bbox: Tuple[float, float, float, float]) -> Optional[OverlayBox]:
+        left, top, right, bottom = bbox
+        if abs(right - left) < 4 or abs(bottom - top) < 4:
+            return None
+        base_bbox = self._display_to_base_bbox(bbox)
+        order_key, line_key = self._next_manual_keys()
+        token = OcrToken(text="", bbox=base_bbox, order_key=order_key, line_key=line_key)
+        overlay = self._create_overlay_widget(
+            token,
+            left,
+            top,
+            right,
+            bottom,
+            preset_text="",
+            is_manual=True,
+        )
+        overlay.entry.focus_set()
+        self._clear_selection()
+        self.selected_rects.add(overlay.rect_id)
+        self._set_box_selected(overlay, True)
+        self._update_entry_focus()
+        self._refresh_delete_button()
+        return overlay
+
+    def _update_tokens_snapshot(self) -> None:
+        self.current_tokens = [item.token for item in self.overlay_items]
+
+    def _set_box_selected(self, overlay: OverlayBox, selected: bool) -> None:
+        overlay.selected = selected
+        outline = "#F2994A" if selected else "#2F80ED"
+        width = 2 if selected else 1
+        try:
+            self.canvas.itemconfigure(overlay.rect_id, outline=outline, width=width)
+        except tk.TclError:
+            return
+
+    def _clear_selection(self) -> None:
+        for rect in list(self.selected_rects):
+            overlay = self.rect_to_overlay.get(rect)
+            if overlay is None:
+                continue
+            self._set_box_selected(overlay, False)
+        self.selected_rects.clear()
+        self._refresh_delete_button()
+
+    def _refresh_delete_button(self) -> None:
+        if hasattr(self, "delete_button"):
+            state = tk.NORMAL if self.selected_rects else tk.DISABLED
+            try:
+                self.delete_button.config(state=state)
+            except tk.TclError:
+                pass
+
+    def _update_entry_focus(self) -> None:
+        if len(self.selected_rects) != 1:
+            return
+        rect_id = next(iter(self.selected_rects))
+        overlay = self.rect_to_overlay.get(rect_id)
+        if overlay is None:
+            return
+        try:
+            overlay.entry.focus_set()
+        except tk.TclError:
+            pass
+
+    def _delete_selected(self) -> None:
+        overlays = [self.rect_to_overlay.get(rect) for rect in list(self.selected_rects)]
+        overlays = [overlay for overlay in overlays if overlay is not None]
+        if not overlays:
+            return
+        for overlay in overlays:
+            self._remove_overlay(overlay)
+        self.selected_rects.clear()
+        self._refresh_delete_button()
+        self._update_tokens_snapshot()
+        self._update_combined_transcription()
+
+    def _remove_overlay(self, overlay: OverlayBox) -> None:
+        try:
+            overlay.entry.destroy()
+        except tk.TclError:
+            pass
+        self.canvas.delete(overlay.rect_id)
+        self.canvas.delete(overlay.window_id)
+        if overlay.rect_id in self.rect_to_overlay:
+            del self.rect_to_overlay[overlay.rect_id]
+        try:
+            self.overlay_items.remove(overlay)
+        except ValueError:
+            pass
+        try:
+            self.overlay_entries.remove(overlay.entry)
+        except ValueError:
+            pass
+
+    def _get_mode(self) -> str:
+        if hasattr(self, "mode_var"):
+            try:
+                return self.mode_var.get()
+            except AttributeError:
+                return str(self.mode_var)
+        return "select"
+
+    def _event_has_ctrl(self, event: tk.Event) -> bool:
+        return bool(getattr(event, "state", 0) & CONTROL_MASK)
+
+    def _event_has_shift(self, event: tk.Event) -> bool:
+        return bool(getattr(event, "state", 0) & SHIFT_MASK)
+
+    def _find_overlay_at(self, x: float, y: float) -> Optional[OverlayBox]:
+        for overlay in reversed(self.overlay_items):
+            coords = self.canvas.coords(overlay.rect_id)
+            if len(coords) != 4:
+                continue
+            left, top, right, bottom = coords
+            if left <= x <= right and top <= y <= bottom:
+                return overlay
+        return None
+
+    def _overlays_in_rect(self, bbox: Tuple[float, float, float, float]) -> List[OverlayBox]:
+        left, top, right, bottom = bbox
+        selected: list[OverlayBox] = []
+        for overlay in self.overlay_items:
+            coords = self.canvas.coords(overlay.rect_id)
+            if len(coords) != 4:
+                continue
+            o_left, o_top, o_right, o_bottom = coords
+            if o_left >= right or o_right <= left or o_top >= bottom or o_bottom <= top:
+                continue
+            selected.append(overlay)
+        return selected
+
+    def _apply_single_selection(self, overlay: OverlayBox, additive: bool) -> None:
+        if additive:
+            if overlay.rect_id in self.selected_rects:
+                self.selected_rects.remove(overlay.rect_id)
+                self._set_box_selected(overlay, False)
+            else:
+                self.selected_rects.add(overlay.rect_id)
+                self._set_box_selected(overlay, True)
+        else:
+            if self.selected_rects == {overlay.rect_id}:
+                pass
+            else:
+                self._clear_selection()
+                self.selected_rects.add(overlay.rect_id)
+                self._set_box_selected(overlay, True)
+        self._refresh_delete_button()
+        self._update_entry_focus()
+
+    def _apply_marquee_selection(self, overlays: Sequence[OverlayBox], additive: bool) -> None:
+        if not additive:
+            self._clear_selection()
+        for overlay in overlays:
+            self.selected_rects.add(overlay.rect_id)
+            self._set_box_selected(overlay, True)
+        self._refresh_delete_button()
+        self._update_entry_focus()
+
+    def _on_canvas_button_press(self, event: tk.Event) -> None:
+        self.canvas.focus_set()
+        self._drag_start = (event.x, event.y)
+        self._active_temp_rect = None
+        self._marquee_rect = None
+        self._modifier_drag = False
+        mode = self._get_mode()
+        if mode == "draw":
+            self._active_temp_rect = self.canvas.create_rectangle(
+                event.x,
+                event.y,
+                event.x,
+                event.y,
+                outline="#2F80ED",
+                dash=(4, 2),
+                tags="overlay-temp",
+            )
+        else:
+            has_modifier = self._event_has_ctrl(event) or self._event_has_shift(event)
+            self._modifier_drag = has_modifier
+            overlay = self._find_overlay_at(event.x, event.y)
+            self._pressed_overlay = overlay
+            if overlay is not None and not has_modifier:
+                self._apply_single_selection(overlay, additive=False)
+            elif overlay is None and not has_modifier:
+                self._clear_selection()
+
+    def _on_canvas_drag(self, event: tk.Event) -> None:
+        if self._drag_start is None:
+            return
+        mode = self._get_mode()
+        if mode == "draw":
+            if self._active_temp_rect is None:
+                self._active_temp_rect = self.canvas.create_rectangle(
+                    self._drag_start[0],
+                    self._drag_start[1],
+                    event.x,
+                    event.y,
+                    outline="#2F80ED",
+                    dash=(4, 2),
+                    tags="overlay-temp",
+                )
+            else:
+                self.canvas.coords(
+                    self._active_temp_rect,
+                    self._drag_start[0],
+                    self._drag_start[1],
+                    event.x,
+                    event.y,
+                )
+        else:
+            if not self._modifier_drag:
+                return
+            if self._marquee_rect is None:
+                self._marquee_rect = self.canvas.create_rectangle(
+                    self._drag_start[0],
+                    self._drag_start[1],
+                    event.x,
+                    event.y,
+                    outline="#F2994A",
+                    dash=(3, 2),
+                    tags="marquee",
+                )
+            else:
+                self.canvas.coords(
+                    self._marquee_rect,
+                    self._drag_start[0],
+                    self._drag_start[1],
+                    event.x,
+                    event.y,
+                )
+
+    def _on_canvas_release(self, event: tk.Event) -> None:
+        if self._drag_start is None:
+            return
+        mode = self._get_mode()
+        if mode == "draw":
+            if self._active_temp_rect is not None:
+                coords = self.canvas.coords(self._active_temp_rect)
+                self.canvas.delete(self._active_temp_rect)
+                if len(coords) == 4:
+                    left, top, right, bottom = coords
+                    bbox = (min(left, right), min(top, bottom), max(left, right), max(top, bottom))
+                    overlay = self._create_manual_overlay(bbox)
+                    if overlay is not None:
+                        self._update_combined_transcription()
+            self._active_temp_rect = None
+        else:
+            if self._marquee_rect is not None:
+                coords = self.canvas.coords(self._marquee_rect)
+                self.canvas.delete(self._marquee_rect)
+                if len(coords) == 4:
+                    left, top, right, bottom = coords
+                    bbox = (min(left, right), min(top, bottom), max(left, right), max(top, bottom))
+                    overlays = self._overlays_in_rect(bbox)
+                    additive = self._modifier_drag
+                    self._apply_marquee_selection(overlays, additive=additive)
+            else:
+                overlay = self._pressed_overlay
+                if overlay is not None:
+                    additive = self._event_has_ctrl(event) or self._event_has_shift(event)
+                    if additive or overlay.rect_id not in self.selected_rects:
+                        self._apply_single_selection(overlay, additive=additive)
+                elif not (self._event_has_ctrl(event) or self._event_has_shift(event)):
+                    self._clear_selection()
+        self._pressed_overlay = None
+        self._drag_start = None
+        self._marquee_rect = None
+        self._modifier_drag = False
 
     def _extract_tokens(self, image: Image.Image) -> List[OcrToken]:
         ocr_image: Optional[Image.Image] = None
@@ -424,10 +805,12 @@ class AnnotationApp:
 
     def _compose_transcription(self) -> str:
         lines: dict[LineKey, list[Tuple[int, str]]] = {}
-        for token, entry in zip(self.current_tokens, self.overlay_entries):
-            value = entry.get().strip()
+        overlays = sorted(self.overlay_items, key=lambda item: item.token.order_key)
+        for overlay in overlays:
+            value = overlay.entry.get().strip()
             if not value:
                 continue
+            token = overlay.token
             lines.setdefault(token.line_key, []).append((token.order_key[-1], value))
 
         composed: list[str] = []
@@ -448,12 +831,16 @@ class AnnotationApp:
         return self.entry_widget.get("1.0", tk.END).strip()
 
     def _clear_overlay_entries(self) -> None:
-        for entry in self.overlay_entries:
+        for overlay in list(getattr(self, "overlay_items", [])):
             try:
-                entry.destroy()
+                overlay.entry.destroy()
             except tk.TclError:
                 pass
-        self.overlay_entries.clear()
+        self.overlay_entries = []
+        self.overlay_items = []
+        self.rect_to_overlay = {}
+        self.selected_rects.clear()
+        self.current_tokens = []
 
     def _suggest_label(self, path: Path) -> str:
         stem = path.stem


### PR DESCRIPTION
## Summary
- track and manage annotation overlays through a dedicated data structure with draw/select tooling on the canvas
- support marquee multi-select, selection highlighting, delete shortcuts, and include manual boxes when composing transcriptions
- extend unit coverage to exercise draw/select/delete flows via a stubbed canvas

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e044692080832baf7e3933cfad412e