### PR TITLE
Initialize undo stack for annotation app

### DIFF
--- a/src/annotation.py
+++ b/src/annotation.py
@@ -126,6 +126,7 @@ class AnnotationApp:
         self.overlay_items: list[OverlayBox] = []
         self.rect_to_overlay: Dict[int, OverlayBox] = {}
         self.selected_rects: Set[int] = set()
+        self._undo_stack: list[list[RemovedOverlay]] = []
         self.current_tokens: list[OcrToken] = []
         self.display_scale: Tuple[float, float] = (1.0, 1.0)
         self.manual_token_counter = 0


### PR DESCRIPTION
## Summary
- initialize the annotation app undo stack alongside other overlay collections to avoid attribute errors when accessed

## Testing
- python main.py annotate *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68e15c452014832bb72f90015df2aaca