### PR TITLE
Keep overlay entries visible when unselected

### DIFF
--- a/src/annotation.py
+++ b/src/annotation.py
@@ -561,8 +561,12 @@ class AnnotationApp:
         width = 2 if overlay.selected else 1
         try:
             self.canvas.itemconfigure(view.rect_id, outline=outline, width=width)
-            state = "normal" if overlay.selected else "hidden"
-            self.canvas.itemconfigure(view.window_id, state=state)
+            self.canvas.itemconfigure(view.window_id, state="normal")
+            if hasattr(view.entry, "configure"):
+                bg = "#FFFFFF" if overlay.selected else "#F8F9FA"
+                fg = "#000000"
+                view.entry.configure(state=tk.NORMAL)
+                view.entry.configure(bg=bg, fg=fg, insertbackground=fg)
         except tk.TclError:
             pass
 


### PR DESCRIPTION
## Summary
- keep overlay entry windows visible by leaving the canvas window items in a normal state
- adjust entry styling while preserving selection highlights so keyboard focus continues to work

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e18e2f9038832bb71235041a8cc4d3