### PR TITLE
Fix marquee selection fallback when clicking empty canvas

### DIFF
--- a/src/annotation.py
+++ b/src/annotation.py
@@ -660,16 +660,18 @@ class AnnotationApp:
             else:
                 self.store.select_click(overlay_id, additive=True)
             return
-        base_bbox = self._to_base(bbox)
-        overlay_id = self.store.add_manual(base_bbox)
-        self.store.set_status("Added manual overlay")
-        self.store.request_focus(overlay_id)
 
-        if additive:
-            self._drag_mode = "marquee"
-            self._marquee_additive = True
-            self._marquee_rect = self.canvas.create_rectangle(x, y, x, y, outline="#F2994A", dash=(4, 2))
-        else:
+        self._drag_mode = "marquee"
+        self._marquee_additive = additive
+        self._marquee_rect = self.canvas.create_rectangle(
+            x,
+            y,
+            x,
+            y,
+            outline="#F2994A" if additive else "#2F80ED",
+            dash=(4, 2),
+        )
+        if not additive:
             self.store.clear_selection()
 
     def _on_canvas_drag(self, event: tk.Event) -> None:


### PR DESCRIPTION
## Summary
- avoid creating manual overlays during select mode to prevent undefined bbox references
- initialize marquee drag state when clicking empty space so modifier selections work without errors

## Testing
- python main.py annotate --help *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68e18f853314832ba57525653064e541