### PR TITLE
Include paragraph grouping in line keys

### DIFF
--- a/src/annotation.py
+++ b/src/annotation.py
@@ -32,7 +32,7 @@ except ImportError:  # pragma: no cover - fallback when running as script
 
 
 TokenOrder = Tuple[int, int, int, int, int]
-LineKey = Tuple[int, int, int]
+LineKey = Tuple[int, int, int, int]
 
 CONTROL_MASK = 0x0004
 SHIFT_MASK = 0x0001
@@ -1199,7 +1199,7 @@ class AnnotationApp:
 
             bbox = (left, top, left + width, top + height)
             order_key: TokenOrder = (page, block, paragraph, line, word)
-            line_key: LineKey = (page, block, line)
+            line_key: LineKey = (page, block, paragraph, line)
             tokens.append(OcrToken(text=text, bbox=bbox, order_key=order_key, line_key=line_key))
 
         tokens.sort(key=lambda token: token.order_key)

--- a/src/overlay_store.py
+++ b/src/overlay_store.py
@@ -7,7 +7,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Protocol, Sequence,
 
 BBox = Tuple[int, int, int, int]
 TokenOrder = Tuple[int, int, int, int, int]
-LineKey = Tuple[int, int, int]
+LineKey = Tuple[int, int, int, int]
 Listener = Callable[[object], None]
 
 
@@ -282,7 +282,7 @@ class OverlayStore:
             text="",
             is_manual=True,
             order_key=(9999, 0, 0, overlay_id, overlay_id),
-            line_key=(9999, 0, overlay_id),
+            line_key=(9999, 0, 0, overlay_id),
         )
         command = AddOverlay([overlay], index=index)
         self.do(command)


### PR DESCRIPTION
## Summary
- add the paragraph number to LineKey definitions and token extraction so line grouping respects paragraph boundaries
- update manual overlays to supply the expanded line key while keeping composition logic intact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e198df9368832b82c0bffc8af27afa