### PR TITLE
Preserve paragraph spacing when composing OCR text

### DIFF
--- a/src/overlay_store.py
+++ b/src/overlay_store.py
@@ -285,8 +285,8 @@ class OverlayStore:
             bbox_base=bbox_base,
             text="",
             is_manual=True,
-            order_key=(9999, 0, 0, overlay_id, overlay_id),
-            paragraph_key=(9999, 0, overlay_id),
+            order_key=(9999, overlay_id, overlay_id, overlay_id, overlay_id),
+            paragraph_key=(9999, overlay_id, overlay_id),
             line_key=(9999, overlay_id, overlay_id),
         )
         command = AddOverlay([overlay], index=index)

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -233,6 +233,59 @@ def test_apply_transcription_clears_overlay_entries():
     assert all(entry.value == "" for entry in entries)
 
 
+def test_compose_text_from_tokens_groups_lines_and_paragraphs() -> None:
+    app = AnnotationApp.__new__(AnnotationApp)
+    tokens = [
+        annotation.OcrToken(
+            "hello",
+            (0, 0, 0, 0),
+            (1, 1, 1, 1, 1),
+            (1, 1, 1),
+            (1, 1, 1),
+        ),
+        annotation.OcrToken(
+            "there",
+            (0, 0, 0, 0),
+            (1, 1, 1, 1, 2),
+            (1, 1, 1),
+            (1, 1, 1),
+        ),
+        annotation.OcrToken(
+            "general",
+            (0, 0, 0, 0),
+            (1, 1, 1, 2, 1),
+            (1, 1, 1),
+            (1, 1, 2),
+        ),
+        annotation.OcrToken(
+            "kenobi",
+            (0, 0, 0, 0),
+            (1, 1, 1, 2, 2),
+            (1, 1, 1),
+            (1, 1, 2),
+        ),
+        annotation.OcrToken(
+            "Another",
+            (0, 0, 0, 0),
+            (1, 1, 2, 1, 1),
+            (1, 1, 2),
+            (1, 1, 3),
+        ),
+        annotation.OcrToken(
+            "paragraph",
+            (0, 0, 0, 0),
+            (1, 1, 2, 1, 2),
+            (1, 1, 2),
+            (1, 1, 3),
+        ),
+    ]
+
+    assert (
+        AnnotationApp._compose_text_from_tokens(app, tokens)
+        == "hello there\ngeneral kenobi\n\nAnother paragraph"
+    )
+
+
 def test_confirm_revisit_uses_persisted_metadata(tmp_path):
     app = AnnotationApp.__new__(AnnotationApp)
     image_path = tmp_path / "sample.png"

--- a/tests/test_overlay_store.py
+++ b/tests/test_overlay_store.py
@@ -57,6 +57,8 @@ def test_manual_add_remove_and_history() -> None:
     assert store.selection == (manual_id,)
     manual_overlay = store.get_overlay(manual_id)
     assert manual_overlay is not None and manual_overlay.is_manual
+    assert manual_overlay.paragraph_key == (9999, manual_id, manual_id)
+    assert manual_overlay.line_key == (9999, manual_id, manual_id)
 
     removed = store.remove_by_ids([manual_id])
     assert [overlay.id for overlay in removed] == [manual_id]


### PR DESCRIPTION
## Summary
- propagate paragraph and line keys through OCR tokens and overlays so composition can distinguish paragraphs
- ensure manual overlays use stable paragraph metadata and preserve grouped words when composing text
- add regression coverage for paragraph-aware text composition in both the annotation helper and overlay store

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1b7fb01b8832bb7044557d2dbef76