### PR TITLE
Refactor annotation workflow for Kraken line baselines

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,21 @@ evaluate the updated model.
 > **Note:** The annotation interface relies on Tkinter, which ships with most
 > standard Python installers. On some Linux distributions you may need to
 > install an additional package such as `python3-tk` to enable the GUI.
+
+## Kraken installation (Windows quick start)
+
+1. Install [Python 3.10+](https://www.python.org/downloads/windows/) and ensure "Add python.exe to PATH" is ticked during setup.
+2. Open **PowerShell** and install [pipx](https://pypa.github.io/pipx/) if it is not already available:
+
+   ```powershell
+   python -m pip install --user pipx
+   python -m pipx ensurepath
+   ```
+
+3. Close and reopen PowerShell, then install Kraken together with its CLI tools:
+
+   ```powershell
+   pipx install "kraken[serve]"
+   ```
+
+4. Confirm the installation with `kraken --version` and `ketos --help`. Both commands should be available in any new shell session.

--- a/src/annotation.py
+++ b/src/annotation.py
@@ -1,104 +1,91 @@
-"""GUI for manually annotating handwriting samples."""
+"""GUI for baseline-based handwriting annotation."""
 from __future__ import annotations
 
 import csv
 import logging
-import re
 import threading
-from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import tkinter as tk
 from tkinter import messagebox
 
 from PIL import Image, ImageOps, ImageTk
-import pytesseract
-from pytesseract import Output
 
-try:  # pragma: no cover - package/runtime compatibility
-    from .overlay_store import (
-        OcrToken,
-        Overlay,
-        OverlayStore,
-    )
-except ImportError:  # pragma: no cover - fallback when running as script
-    from overlay_store import (  # type: ignore
-        OcrToken,
-        Overlay,
-        OverlayStore,
-    )
-
-
-TokenOrder = Tuple[int, int, int, int, int]
-ParagraphKey = Tuple[int, int, int]
-LineKey = Tuple[int, int, int]
+from .exporters import save_line_crops, save_pagexml
+from .kraken_adapter import is_available as kraken_available, segment_lines
+from .line_store import AddLine, LineStore, Point, RemoveLines, SetSelection, UpdateText
 
 CONTROL_MASK = 0x0004
 SHIFT_MASK = 0x0001
-MIN_DRAW_SIZE = 8
 
 
-@dataclass(slots=True)
+@dataclass
 class AnnotationItem:
-    """Represent a single image queued for annotation."""
-
     path: Path
     label: Optional[str] = None
     status: Optional[str] = None
     saved_path: Optional[Path] = None
 
 
-@dataclass(slots=True)
-class OverlayView:
-    overlay_id: int
-    rect_id: int
-    window_id: int
-    entry: tk.Entry
+@dataclass
+class AnnotationOptions:
+    engine: str = "kraken"
+    segmentation: str = "auto"
+    export_format: str = "lines"
 
 
-@dataclass(slots=True)
-class LegacyOverlayItem:
-    overlay_id: int
-    token: OcrToken
-    rect_id: int
-    window_id: int
+@dataclass
+class LineView:
+    line_id: int
+    canvas_item: Optional[int]
+    text_var: tk.StringVar
     entry: tk.Entry
-    is_manual: bool
-    selected: bool
 
 
 def _prepare_image(image: Image.Image) -> Image.Image:
-    """Apply EXIF orientation and return a new image instance."""
-
     return ImageOps.exif_transpose(image)
 
 
 def prepare_image(path: Path) -> Image.Image:
-    """Open ``path`` and apply EXIF-based orientation for consistent display."""
-
     with Image.open(path) as src:
         prepared = _prepare_image(src)
         return prepared.copy()
 
 
+def to_display_point(point: Point, scale: Tuple[float, float]) -> Tuple[float, float]:
+    sx, sy = scale
+    return point[0] * sx, point[1] * sy
+
+
+def to_base_point(point: Tuple[float, float], scale: Tuple[float, float]) -> Point:
+    sx, sy = scale
+    if sx == 0 or sy == 0:
+        return point[0], point[1]
+    return point[0] / sx, point[1] / sy
+
+
+def to_base_bbox(bbox: Tuple[float, float, float, float], scale: Tuple[float, float]) -> Tuple[int, int, int, int]:
+    x1, y1 = to_base_point((bbox[0], bbox[1]), scale)
+    x2, y2 = to_base_point((bbox[2], bbox[3]), scale)
+    return int(x1), int(y1), int(x2), int(y2)
+
+
 class AnnotationApp:
-    """Tkinter-based interface for stepping through a set of images."""
+    """Tkinter-based interface for baseline annotation."""
 
     MAX_SIZE = (900, 700)
-    FADE_DELAY_MS = 150
-    MIN_ZOOM = 0.5
-    MAX_ZOOM = 3.0
-    ZOOM_STEP = 1.1
 
     def __init__(
         self,
         master: tk.Tk,
         items: Iterable[AnnotationItem],
         train_dir: Path,
+        *,
+        options: Optional[AnnotationOptions] = None,
         log_path: Optional[Path] = None,
-        on_sample_saved: Optional[Callable[[Path], None]] = None,
+        on_sample_saved: Optional[callable[[Path], None]] = None,
     ) -> None:
         self.master = master
         self.items: List[AnnotationItem] = list(items)
@@ -107,59 +94,39 @@ class AnnotationApp:
         self.index = 0
         self.train_dir = Path(train_dir)
         self.train_dir.mkdir(parents=True, exist_ok=True)
+        self.options = options or AnnotationOptions()
         self.log_path = Path(log_path) if log_path is not None else None
         if self.log_path is not None:
             self.log_path.parent.mkdir(parents=True, exist_ok=True)
         self._on_sample_saved = on_sample_saved
 
-        self.store = OverlayStore()
-        self._store_unsubscribes = [
-            self.store.on_overlays(self._on_store_overlays),
-            self.store.on_selection(self._on_store_selection),
-            self.store.on_focus(self._on_store_focus),
-            self.store.on_status(self._on_store_status),
-        ]
-
+        self.store = LineStore()
+        self.display_scale: Tuple[float, float] = (1.0, 1.0)
         self.current_photo: Optional[ImageTk.PhotoImage] = None
         self.canvas_image_id: Optional[int] = None
-        self.display_scale: Tuple[float, float] = (1.0, 1.0)
-        self._base_display_image: Optional[Image.Image] = None
-        self._base_scale: Tuple[float, float] = (1.0, 1.0)
-        self.zoom_factor: float = 1.0
+        self._base_image: Optional[Image.Image] = None
 
-        self.overlay_views: Dict[int, OverlayView] = {}
-        self._overlay_positions: Dict[int, Tuple[float, float, float, float]] = {}
-        self.overlay_entries: List[tk.Entry] = []
-        self.overlay_items: List[LegacyOverlayItem] = []
-        self.rect_to_overlay: Dict[int, LegacyOverlayItem] = {}
-        self.selected_rects: Set[int] = set()
-        self.current_tokens: List[OcrToken] = []
-        self._entry_guard = False
-
-        self._drag_start: Optional[Tuple[float, float]] = None
-        self._drag_mode: Optional[str] = None
-        self._pending_click_id: Optional[int] = None
-        self._active_draw_rect: Optional[int] = None
-        self._marquee_rect: Optional[int] = None
-        self._marquee_additive = False
-        self._resize_overlay_id: Optional[int] = None
-        self._resize_original_bbox: Optional[Tuple[float, float, float, float]] = None
-        self._resize_original_base_bbox: Optional[Tuple[int, int, int, int]] = None
-        self._resize_anchor: Optional[Tuple[str, str]] = None
-        self._resize_press_point: Optional[Tuple[float, float]] = None
-        self._resize_changed = False
-
-        self.filename_var = tk.StringVar()
-        self.status_var = tk.StringVar()
         self.mode_var = tk.StringVar(value="select")
+        self.status_var = tk.StringVar()
+        self.filename_var = tk.StringVar()
         self._user_modified_transcription = False
         self._setting_transcription = False
+
+        self.canvas: tk.Canvas
+        self.entry_widget: tk.Text
+        self.delete_button: tk.Button
+        self.back_button: tk.Button
+        self.lines_frame: tk.Frame
+
+        self.line_views: Dict[int, LineView] = {}
+        self._drawing_points: List[Point] = []
+        self._drawing_canvas_item: Optional[int] = None
 
         self._build_ui()
         self._show_current()
 
     # ------------------------------------------------------------------
-    # UI building
+    # UI construction
     # ------------------------------------------------------------------
     def _build_ui(self) -> None:
         self.master.title("Standup-OCR Annotation")
@@ -183,61 +150,50 @@ class AnnotationApp:
         v_scroll.grid(row=0, column=1, sticky="ns")
         h_scroll = tk.Scrollbar(canvas_frame, orient="horizontal", command=self.canvas.xview)
         h_scroll.grid(row=1, column=0, sticky="ew")
-
         self.canvas.configure(xscrollcommand=h_scroll.set, yscrollcommand=v_scroll.set)
-        self.canvas.bind("<ButtonPress-1>", self._on_canvas_button_press)
-        self.canvas.bind("<B1-Motion>", self._on_canvas_drag)
-        self.canvas.bind("<ButtonRelease-1>", self._on_canvas_release)
-        self.canvas.bind("<MouseWheel>", self._on_canvas_mousewheel)
-        self.canvas.bind("<Button-4>", self._on_canvas_mousewheel)  # X11 scroll up
-        self.canvas.bind("<Button-5>", self._on_canvas_mousewheel)  # X11 scroll down
 
         toolbar = tk.Frame(container)
         toolbar.pack(anchor="w", pady=(0, 8))
-
-        select_btn = tk.Radiobutton(toolbar, text="Select", variable=self.mode_var, value="select")
-        select_btn.pack(side="left")
-        draw_btn = tk.Radiobutton(toolbar, text="Draw", variable=self.mode_var, value="draw")
-        draw_btn.pack(side="left", padx=(8, 0))
-        zoom_btn = tk.Radiobutton(toolbar, text="Zoom", variable=self.mode_var, value="zoom")
-        zoom_btn.pack(side="left", padx=(8, 0))
+        tk.Radiobutton(toolbar, text="Select", variable=self.mode_var, value="select").pack(side="left")
+        tk.Radiobutton(toolbar, text="Draw", variable=self.mode_var, value="draw").pack(side="left", padx=(8, 0))
 
         delete_btn = tk.Button(toolbar, text="Delete Selected", command=self._delete_selected, state=tk.DISABLED)
         delete_btn.pack(side="left", padx=(16, 0))
         self.delete_button = delete_btn
 
+        lines_container = tk.LabelFrame(container, text="Lines")
+        lines_container.pack(fill="x", pady=(0, 8))
+        self.lines_frame = tk.Frame(lines_container)
+        self.lines_frame.pack(fill="x")
+
         entry_frame = tk.Frame(container)
         entry_frame.pack(fill="x", pady=(0, 8))
-
         tk.Label(entry_frame, text="Transcription:").pack(side="left")
         text_widget = tk.Text(entry_frame, height=4, wrap="word")
         text_widget.pack(side="left", fill="both", expand=True, padx=(8, 0))
+        text_widget.bind("<Key>", self._on_transcription_modified)
         text_widget.bind("<Control-Return>", self._on_confirm)
         text_widget.bind("<Command-Return>", self._on_confirm)
-        text_widget.bind("<Key>", self._on_transcription_modified)
         self.entry_widget = text_widget
 
         buttons = tk.Frame(container)
         buttons.pack(pady=(0, 8))
-
         back_btn = tk.Button(buttons, text="Back", command=self.back)
         back_btn.pack(side="left", padx=4)
         self.back_button = back_btn
-        self.back_button.config(state=tk.DISABLED)
-
         confirm_btn = tk.Button(buttons, text="Confirm", command=self.confirm, default=tk.ACTIVE)
         confirm_btn.pack(side="left", padx=4)
+        tk.Button(buttons, text="Skip", command=self.skip).pack(side="left", padx=4)
+        tk.Button(buttons, text="Unsure", command=self.unsure).pack(side="left", padx=4)
 
-        skip_btn = tk.Button(buttons, text="Skip", command=self.skip)
-        skip_btn.pack(side="left", padx=4)
+        status_label = tk.Label(container, textvariable=self.status_var, fg="gray")
+        status_label.pack(anchor="w")
 
-        unsure_btn = tk.Button(buttons, text="Unsure", command=self.unsure)
-        unsure_btn.pack(side="left", padx=4)
+        self.canvas.bind("<ButtonPress-1>", self._on_canvas_press)
+        self.canvas.bind("<B1-Motion>", self._on_canvas_drag)
+        self.canvas.bind("<ButtonRelease-1>", self._on_canvas_release)
 
-        self.status_label = tk.Label(container, textvariable=self.status_var, fg="gray")
-        self.status_label.pack(anchor="w")
-
-        self.master.bind("<Escape>", self._on_exit)
+        self.master.bind("<Escape>", self._on_escape)
         self.master.bind("<Delete>", self._on_delete_selected)
         self.master.bind("<BackSpace>", self._on_delete_selected)
         self.master.bind("<Control-z>", self._on_undo)
@@ -245,63 +201,77 @@ class AnnotationApp:
         self.master.bind("<Control-y>", self._on_redo)
         self.master.bind("<Control-Y>", self._on_redo)
         self.master.bind("<Control-Shift-Z>", self._on_redo)
+        self.master.bind("<Alt-Left>", lambda event: self.back())
+        self.master.bind("<Return>", self._on_return)
+
         self.master.protocol("WM_DELETE_WINDOW", self._on_exit)
 
     # ------------------------------------------------------------------
-    # Navigation & item display
+    # Navigation
     # ------------------------------------------------------------------
     def _on_confirm(self, event: Optional[tk.Event]) -> None:
         self.confirm()
+
+    def _on_escape(self, event: Optional[tk.Event]) -> None:
+        if self._drawing_points:
+            self._cancel_drawing()
+        else:
+            self._on_exit()
 
     def _on_exit(self, event: Optional[tk.Event] = None) -> None:
         if messagebox.askokcancel("Quit", "Abort annotation and close the window?"):
             self.master.destroy()
 
     def confirm(self) -> None:
-        label = self._get_transcription_text()
-        if not label:
-            messagebox.showinfo("Missing text", "Enter a transcription or choose Skip/Unsure.")
+        if not self.store.list():
+            messagebox.showinfo("No lines", "Create at least one line before confirming.")
             return
+        text = self.store.compose_text().strip()
+        if not text:
+            if not messagebox.askyesno(
+                "Empty transcription",
+                "No text was entered for the selected lines. Export anyway?",
+            ):
+                return
 
         item = self.items[self.index]
         try:
-            saved_path = self._save_annotation(item.path, label)
-        except OSError as exc:
-            messagebox.showerror("Save failed", f"Could not save annotation: {exc}")
+            saved_path = self._export_lines(item)
+        except Exception as exc:
+            logging.exception("Export failed")
+            messagebox.showerror("Export failed", f"Could not export training data: {exc}")
             return
-        item.label = label
+
+        item.label = text
         item.status = "confirmed"
         item.saved_path = saved_path
-        self._append_log(item.path, label, "confirmed", saved_path)
-        self.status_var.set(f"Saved to {saved_path.name}")
-        callback = getattr(self, "_on_sample_saved", None)
-        if callback is not None and saved_path is not None:
-            callback(saved_path)
+        self._append_log(item.path, text, "confirmed", saved_path)
+        self.status_var.set("Exported training data")
+        if self._on_sample_saved is not None and saved_path is not None:
+            self._on_sample_saved(saved_path)
         self._advance()
 
     def skip(self) -> None:
         item = self.items[self.index]
-        item.label = ""
         item.status = "skipped"
+        item.label = ""
         item.saved_path = None
-        self._append_log(item.path, item.label, "skipped", None)
+        self._append_log(item.path, "", "skipped", None)
         self.status_var.set("Skipped")
         self._advance()
 
     def unsure(self) -> None:
         item = self.items[self.index]
-        label = self._get_transcription_text()
-        item.label = label
         item.status = "unsure"
+        item.label = self.store.compose_text()
         item.saved_path = None
-        self._append_log(item.path, label, "unsure", None)
+        self._append_log(item.path, item.label or "", "unsure", None)
         self.status_var.set("Marked as unsure")
         self._advance()
 
     def back(self) -> None:
         if self.index == 0:
-            self.back_button.config(state=tk.DISABLED)
-            self.status_var.set("Already at the first item.")
+            self.status_var.set("Already at the first item")
             return
         self.index -= 1
         self._show_current(revisit=True)
@@ -317,962 +287,86 @@ class AnnotationApp:
     def _show_current(self, *, revisit: bool = False) -> None:
         item = self.items[self.index]
         self.filename_var.set(f"{item.path.name} ({self.index + 1}/{len(self.items)})")
-        self._user_modified_transcription = False
         self.back_button.config(state=tk.NORMAL if self.index > 0 else tk.DISABLED)
-        self._display_item(item)
+        self._user_modified_transcription = False
+        self._load_item(item)
         self.entry_widget.focus_set()
         if revisit:
-            previous_status = self.status_var.get() or ""
-            reminder = "Returned to previous item; previous response has not been re-recorded."
-            if reminder not in previous_status:
-                message = f"{previous_status} {reminder}".strip()
-                self.status_var.set(message)
+            self.status_var.set("Returned to previous item.")
 
-    def _display_item(self, item: AnnotationItem) -> None:
-        path = item.path
+    # ------------------------------------------------------------------
+    # Item display and export
+    # ------------------------------------------------------------------
+    def _load_item(self, item: AnnotationItem) -> None:
+        self._clear_canvas()
+        self.store = LineStore()
+        self.line_views.clear()
         try:
-            with Image.open(path) as image:
+            with Image.open(item.path) as image:
                 image = _prepare_image(image)
-                image = image.convert("RGBA")
-                image.thumbnail(self.MAX_SIZE, Image.LANCZOS)
-                prepared_image = image.copy()
-        except Exception as exc:  # pragma: no cover - GUI feedback only
-            messagebox.showerror("Error", f"Could not open {path.name}: {exc}")
+                base_image = image.convert("RGB")
+        except Exception as exc:
+            messagebox.showerror("Error", f"Could not open {item.path.name}: {exc}")
             self.skip()
             return
 
-        tokens: List[OcrToken] = []
-        prefilled = False
-        if item.status == "confirmed" and item.label:
-            self._set_transcription(item.label)
-            if item.saved_path:
-                saved_name = Path(item.saved_path).name or str(item.saved_path)
-                self.status_var.set(f"Previously saved to {saved_name}")
-            else:
-                self.status_var.set("Previously confirmed.")
-            prefilled = True
-        elif item.status == "unsure":
-            self._set_transcription(item.label or "")
-            self.status_var.set("Previously marked as unsure.")
-            prefilled = True
-        elif item.status == "skipped":
-            self._set_transcription("")
-            self.status_var.set("Previously skipped.")
-            prefilled = True
-        elif item.label:
-            self._set_transcription(item.label)
-            self.status_var.set("Previously annotated.")
-            prefilled = True
+        self._base_image = base_image
+        display = base_image.copy()
+        display.thumbnail(self.MAX_SIZE, Image.LANCZOS)
+        sx = display.width / base_image.width if base_image.width else 1.0
+        sy = display.height / base_image.height if base_image.height else 1.0
+        self.display_scale = (sx, sy)
 
-        if not prefilled:
-            tokens = self._extract_tokens(prepared_image)
-            suggestion = self._compose_text_from_tokens(tokens)
-            if suggestion:
-                self._set_transcription(suggestion)
-                self.status_var.set("Pre-filled transcription using OCR result.")
-            else:
-                self._set_transcription("")
-                filename_hint = self._suggest_label(path)
-                if filename_hint:
-                    self.status_var.set(
-                        "OCR produced no suggestion; using filename hint: "
-                        f"{filename_hint}"
-                    )
-                else:
-                    self.status_var.set("OCR produced no suggestion; please transcribe manually.")
+        self.current_photo = ImageTk.PhotoImage(display)
+        self.canvas_image_id = self.canvas.create_image(0, 0, anchor="nw", image=self.current_photo)
+        self.canvas.configure(scrollregion=(0, 0, display.width, display.height))
 
-        self._display_image(prepared_image, tokens)
-        prepared_image.close()
+        if item.label:
+            self.entry_widget.delete("1.0", tk.END)
+            self.entry_widget.insert("1.0", item.label)
+        else:
+            self.entry_widget.delete("1.0", tk.END)
 
-    # ------------------------------------------------------------------
-    # Canvas rendering & interactions
-    # ------------------------------------------------------------------
-    def _display_image(self, image: Image.Image, tokens: Sequence[OcrToken]) -> None:
-        if not hasattr(self, "overlay_views"):
-            self.overlay_views = {}
-        if not hasattr(self, "_overlay_positions"):
-            self._overlay_positions = {}
-        if not hasattr(self, "overlay_entries"):
-            self.overlay_entries = []
-        if not hasattr(self, "store"):
-            self.store = OverlayStore()
-            self._store_unsubscribes = [
-                self.store.on_overlays(self._on_store_overlays),
-                self.store.on_selection(self._on_store_selection),
-                self.store.on_focus(self._on_store_focus),
-                self.store.on_status(self._on_store_status),
-            ]
+        if self.options.segmentation == "auto" and self.options.engine == "kraken":
+            self._auto_segment(item.path)
+        else:
+            self.status_var.set("Manual annotation mode")
 
-        base_width, base_height = image.size
-        display_image = image.copy().convert("RGBA")
-        display_image.thumbnail(self.MAX_SIZE, Image.LANCZOS)
-        self._base_display_image = display_image.copy()
-        self._base_scale = (
-            display_image.width / base_width if base_width else 1.0,
-            display_image.height / base_height if base_height else 1.0,
-        )
-        self.display_scale = self._base_scale
-        self.zoom_factor = 1.0
+        self._refresh_lines()
+        self._update_transcription()
 
-        photo = ImageTk.PhotoImage(display_image)
-        self.current_photo = photo
+    def _auto_segment(self, path: Path) -> None:
+        if not kraken_available():
+            self.status_var.set("Kraken not installed; manual segmentation required (pip install kraken[serve]).")
+            return
+        try:
+            baselines = segment_lines(path)
+        except RuntimeError as exc:
+            self.status_var.set(str(exc))
+            return
 
-        self.canvas.delete("all")
-        self.overlay_views.clear()
-        self._overlay_positions.clear()
-        self.overlay_entries.clear()
-
-        self.canvas_image_id = self.canvas.create_image(0, 0, image=photo, anchor="nw")
-        self.canvas.config(scrollregion=(0, 0, display_image.width, display_image.height))
-        if hasattr(self.canvas, "xview_moveto"):
-            self.canvas.xview_moveto(0)
-        if hasattr(self.canvas, "yview_moveto"):
-            self.canvas.yview_moveto(0)
-
-        self.store.set_tokens(tokens)
-        self._render_overlays()
-        self._update_combined_transcription()
-
-    def _render_overlays(self) -> None:
-        overlays = self.store.list_overlays()
-        existing_ids = set(self.overlay_views.keys())
-        seen_ids: Set[int] = set()
-        self.overlay_entries = []
-
-        for overlay in overlays:
-            seen_ids.add(overlay.id)
-            bbox_display = self._to_display(overlay.bbox_base)
-            self._overlay_positions[overlay.id] = bbox_display
-            view = self.overlay_views.get(overlay.id)
-            if view is None:
-                view = self._create_overlay_view(overlay, bbox_display)
-                self.overlay_views[overlay.id] = view
-            else:
-                self._update_overlay_view(view, overlay, bbox_display)
-            self._style_overlay_view(view, overlay)
-            self.overlay_entries.append(view.entry)
-
-        for overlay_id in existing_ids - seen_ids:
-            self._remove_overlay_view(overlay_id)
-
-        self._sync_legacy_structures(overlays)
-        self._refresh_delete_button()
-
-    def _sync_legacy_structures(self, overlays: Sequence[Overlay]) -> None:
-        existing = {item.overlay_id: item for item in getattr(self, "overlay_items", [])}
-        legacy_items: List[LegacyOverlayItem] = []
-        rect_map: Dict[int, LegacyOverlayItem] = {}
-        selected_rects: Set[int] = set()
-        tokens: List[OcrToken] = []
-        for overlay in overlays:
-            view = self.overlay_views.get(overlay.id)
-            if view is None:
+        for baseline in baselines:
+            if len(baseline) < 2:
                 continue
-            token = OcrToken(
-                text=overlay.text,
-                bbox=overlay.bbox_base,
-                order_key=overlay.order_key,
-                paragraph_key=overlay.paragraph_key,
-                line_key=overlay.line_key,
-            )
-            legacy = existing.get(overlay.id)
-            if legacy is None:
-                legacy = LegacyOverlayItem(
-                    overlay_id=overlay.id,
-                    token=token,
-                    rect_id=view.rect_id,
-                    window_id=view.window_id,
-                    entry=view.entry,
-                    is_manual=overlay.is_manual,
-                    selected=overlay.selected,
-                )
-            else:
-                legacy.token = token
-                legacy.rect_id = view.rect_id
-                legacy.window_id = view.window_id
-                legacy.entry = view.entry
-                legacy.is_manual = overlay.is_manual
-                legacy.selected = overlay.selected
-            legacy_items.append(legacy)
-            rect_map[view.rect_id] = legacy
-            if overlay.selected:
-                selected_rects.add(view.rect_id)
-            tokens.append(token)
-        self.overlay_items = legacy_items
-        self.rect_to_overlay = rect_map
-        self.selected_rects = selected_rects
-        self.current_tokens = tokens
-
-    def _create_overlay_view(
-        self, overlay: Overlay, bbox_display: Tuple[float, float, float, float]
-    ) -> OverlayView:
-        left, top, right, bottom = bbox_display
-        rect_id = self.canvas.create_rectangle(
-            left,
-            top,
-            right,
-            bottom,
-            outline="#2F80ED",
-            width=1,
-            tags="overlay",
-        )
-        entry_width = max(4, int(max(1, abs(right - left)) / 8))
-        entry = tk.Entry(self.canvas, width=entry_width)
-        entry.insert(0, overlay.text)
-        entry._overlay_id = overlay.id  # type: ignore[attr-defined]
-        entry.bind("<KeyRelease>", self._on_overlay_entry_changed)
-        entry.bind("<FocusIn>", lambda event, oid=overlay.id: self._on_entry_focus(oid))
-
-        desired_top = top - 24
-        if desired_top < 0:
-            desired_top = top
-        window_id = self.canvas.create_window(
-            left,
-            desired_top,
-            anchor="nw",
-            window=entry,
-            tags="overlay",
-        )
-        if hasattr(self.canvas, "tag_bind"):
-            self.canvas.tag_bind(
-                rect_id,
-                "<ButtonPress-1>",
-                lambda event, oid=overlay.id: self._on_overlay_press(event, oid),
-            )
-            self.canvas.tag_bind(
-                rect_id,
-                "<B1-Motion>",
-                lambda event, oid=overlay.id: self._on_overlay_drag(event, oid),
-            )
-            self.canvas.tag_bind(
-                rect_id,
-                "<ButtonRelease-1>",
-                lambda event, oid=overlay.id: self._on_overlay_release(event, oid),
-            )
-        return OverlayView(overlay.id, rect_id, window_id, entry)
-
-    def _update_overlay_view(
-        self,
-        view: OverlayView,
-        overlay: Overlay,
-        bbox_display: Tuple[float, float, float, float],
-    ) -> None:
-        left, top, right, bottom = bbox_display
-        try:
-            self.canvas.coords(view.rect_id, left, top, right, bottom)
-            desired_top = top - 24 if top - 24 >= 0 else top
-            self.canvas.coords(view.window_id, left, desired_top)
-            width = max(4, int(max(1, abs(right - left)) / 8))
-            if hasattr(view.entry, "configure"):
-                view.entry.configure(width=width)
-        except tk.TclError:
-            pass
-
-        current_text = view.entry.get()
-        if current_text != overlay.text:
-            self._entry_guard = True
-            try:
-                view.entry.delete(0, tk.END)
-                if overlay.text:
-                    view.entry.insert(0, overlay.text)
-            finally:
-                self._entry_guard = False
-
-    def _style_overlay_view(self, view: OverlayView, overlay: Overlay) -> None:
-        outline = "#F2994A" if overlay.selected else "#2F80ED"
-        width = 2 if overlay.selected else 1
-        try:
-            self.canvas.itemconfigure(view.rect_id, outline=outline, width=width)
-            self.canvas.itemconfigure(view.window_id, state="normal")
-            if hasattr(view.entry, "configure"):
-                bg = "#FFFFFF" if overlay.selected else "#F8F9FA"
-                fg = "#000000"
-                view.entry.configure(state=tk.NORMAL)
-                view.entry.configure(bg=bg, fg=fg, insertbackground=fg)
-        except tk.TclError:
-            pass
-
-    def _remove_overlay_view(self, overlay_id: int) -> None:
-        view = self.overlay_views.pop(overlay_id, None)
-        if view is None:
-            return
-        try:
-            self.canvas.delete(view.rect_id)
-            self.canvas.delete(view.window_id)
-        except tk.TclError:
-            pass
-        try:
-            view.entry.destroy()
-        except tk.TclError:
-            pass
-        self._overlay_positions.pop(overlay_id, None)
-
-    def _refresh_delete_button(self) -> None:
-        if not hasattr(self, "store") or not hasattr(self, "delete_button"):
-            return
-        state = tk.NORMAL if self.store.selection else tk.DISABLED
-        try:
-            self.delete_button.config(state=state)
-        except tk.TclError:
-            pass
-
-    def _to_display(self, bbox_base: Tuple[int, int, int, int]) -> Tuple[float, float, float, float]:
-        sx, sy = self.display_scale
-        left, top, right, bottom = bbox_base
-        return (left * sx, top * sy, right * sx, bottom * sy)
-
-    def _to_base(self, bbox_display: Tuple[float, float, float, float]) -> Tuple[int, int, int, int]:
-        sx, sy = self.display_scale
-        if sx == 0 or sy == 0:
-            return tuple(int(value) for value in bbox_display)
-        left, top, right, bottom = bbox_display
-        return (
-            int(round(left / sx)),
-            int(round(top / sy)),
-            int(round(right / sx)),
-            int(round(bottom / sy)),
-        )
-
-    def _event_has_ctrl(self, event: tk.Event) -> bool:
-        return bool(getattr(event, "state", 0) & CONTROL_MASK)
-
-    def _event_has_shift(self, event: tk.Event) -> bool:
-        return bool(getattr(event, "state", 0) & SHIFT_MASK)
-
-    def _canvas_coords(self, x: float, y: float) -> Tuple[float, float]:
-        if hasattr(self.canvas, "canvasx"):
-            x = self.canvas.canvasx(x)
-        if hasattr(self.canvas, "canvasy"):
-            y = self.canvas.canvasy(y)
-        return float(x), float(y)
-
-    def _find_overlay_at_point(self, x: float, y: float) -> Optional[int]:
-        for overlay in reversed(self.store.list_overlays()):
-            bbox = self._overlay_positions.get(overlay.id)
-            if bbox is None:
-                continue
-            left, top, right, bottom = bbox
-            if left <= x <= right and top <= y <= bottom:
-                return overlay.id
-        return None
-
-    def _on_canvas_button_press(self, event: tk.Event) -> None:
-        if self.mode_var.get() == "zoom":
-            focus = self._canvas_coords(event.x, event.y)
-            zoom_out = (
-                getattr(event, "num", 0) == 3
-                or self._event_has_ctrl(event)
-                or self._event_has_shift(event)
-            )
-            step = self.ZOOM_STEP if not zoom_out else 1 / self.ZOOM_STEP
-            self._drag_mode = "zoom"
-            self._drag_start = focus
-            self._pending_click_id = None
-            self._apply_zoom(self.zoom_factor * step, focus=focus)
-            return
-
-        x, y = self._canvas_coords(event.x, event.y)
-        self._drag_start = (x, y)
-        self._pending_click_id = None
-        self._drag_mode = None
-
-        if self.mode_var.get() == "draw":
-            self._drag_mode = "draw"
-            self._active_draw_rect = self.canvas.create_rectangle(x, y, x, y, outline="#2F80ED", dash=(2, 2))
-            self._active_temp_rect = self._active_draw_rect
-            return
-
-        overlay_id = self._find_overlay_at_point(x, y)
-        additive = self._event_has_ctrl(event) or self._event_has_shift(event)
-        if overlay_id is not None:
-            self._pending_click_id = overlay_id
-            if not additive:
-                self.store.select_click(overlay_id, additive=False)
-            else:
-                self.store.select_click(overlay_id, additive=True)
-            return
-
-        self._drag_mode = "marquee"
-        self._marquee_additive = additive
-        self._marquee_rect = self.canvas.create_rectangle(
-            x,
-            y,
-            x,
-            y,
-            outline="#F2994A" if additive else "#2F80ED",
-            dash=(4, 2),
-        )
-        if not additive:
-            self.store.clear_selection()
-
-    def _on_canvas_drag(self, event: tk.Event) -> None:
-        if self._drag_start is None:
-            return
-        if self._drag_mode == "zoom":
-            return
-
-        x, y = self._canvas_coords(event.x, event.y)
-
-        if self._drag_mode == "draw" and self._active_draw_rect is not None:
-            self.canvas.coords(self._active_draw_rect, self._drag_start[0], self._drag_start[1], x, y)
-            return
-
-        if self._drag_mode == "marquee" and self._marquee_rect is not None:
-            self.canvas.coords(self._marquee_rect, self._drag_start[0], self._drag_start[1], x, y)
-            return
-
-    def _on_canvas_release(self, event: tk.Event) -> None:
-        if self._drag_mode == "zoom":
-            self._drag_start = None
-            self._drag_mode = None
-        elif self._drag_mode == "draw":
-            self._finalize_draw()
-        elif self._drag_mode == "marquee":
-            self._finalize_marquee()
-        elif self._pending_click_id is None:
-            if not (self._event_has_ctrl(event) or self._event_has_shift(event)):
-                self.store.clear_selection()
-        self._cleanup_temporary_items()
-
-    def _cleanup_temporary_items(self) -> None:
-        active_rect = getattr(self, "_active_draw_rect", None)
-        if active_rect is None:
-            active_rect = getattr(self, "_active_temp_rect", None)
-        if active_rect is not None:
-            try:
-                self.canvas.delete(active_rect)
-            except tk.TclError:
-                pass
-            self._active_draw_rect = None
-            self._active_temp_rect = None
-        if self._marquee_rect is not None:
-            try:
-                self.canvas.delete(self._marquee_rect)
-            except tk.TclError:
-                pass
-            self._marquee_rect = None
-        self._drag_start = None
-        self._drag_mode = None
-        self._pending_click_id = None
-        self._marquee_additive = False
-        self._reset_resize_state()
-
-    def _finalize_draw(self) -> None:
-        if self._active_draw_rect is None:
-            return
-        coords = self.canvas.coords(self._active_draw_rect)
-        if len(coords) != 4:
-            return
-        left, top, right, bottom = coords
-        bbox = (min(left, right), min(top, bottom), max(left, right), max(top, bottom))
-        if abs(bbox[2] - bbox[0]) < MIN_DRAW_SIZE or abs(bbox[3] - bbox[1]) < MIN_DRAW_SIZE:
-            return
-        base_bbox = self._to_base(bbox)
-        overlay_id = self.store.add_manual(base_bbox)
-        self.store.set_status("Added manual overlay")
-        self.store.request_focus(overlay_id)
-
-    def _finalize_marquee(self) -> None:
-        if self._marquee_rect is None or self._drag_start is None:
-            return
-        coords = self.canvas.coords(self._marquee_rect)
-        if len(coords) != 4:
-            return
-        left, top, right, bottom = coords
-        bbox = (min(left, right), min(top, bottom), max(left, right), max(top, bottom))
-        base_bbox = self._to_base(bbox)
-        ids = self.store.ids_intersecting(base_bbox)
-        if self._marquee_additive:
-            ids |= set(self.store.selection)
-        if ids:
-            self.store.select_set(ids)
-            self.store.set_status(f"Selected {len(ids)} overlays")
-
-    def _on_canvas_mousewheel(self, event: tk.Event) -> str:
-        if self.mode_var.get() != "zoom":
-            return ""
-        delta = getattr(event, "delta", 0)
-        direction = 0
-        if delta > 0:
-            direction = 1
-        elif delta < 0:
-            direction = -1
+            self.store.add_line(baseline, is_manual=False)
+        if baselines:
+            self.status_var.set(f"Loaded {len(baselines)} baselines from Kraken")
         else:
-            num = getattr(event, "num", 0)
-            if num == 4:
-                direction = 1
-            elif num == 5:
-                direction = -1
-        if direction == 0:
-            return ""
-        step = self.ZOOM_STEP if direction > 0 else 1 / self.ZOOM_STEP
-        focus = self._canvas_coords(event.x, event.y)
-        self._apply_zoom(self.zoom_factor * step, focus=focus)
-        return "break"
+            self.status_var.set("Kraken returned no lines; draw them manually")
 
-    def _apply_zoom(
-        self,
-        target: float,
-        *,
-        focus: Optional[Tuple[float, float]] = None,
-    ) -> None:
-        if self._base_display_image is None:
-            return
-        target = max(self.MIN_ZOOM, min(self.MAX_ZOOM, target))
-        if abs(target - self.zoom_factor) < 1e-3:
-            return
-        old_factor = self.zoom_factor
-        base_width, base_height = self._base_display_image.size
-        new_width = max(1, int(base_width * target))
-        new_height = max(1, int(base_height * target))
-        resized = self._base_display_image.resize((new_width, new_height), Image.LANCZOS)
-        photo = ImageTk.PhotoImage(resized)
-        self.current_photo = photo
-        if self.canvas_image_id is None:
-            self.canvas_image_id = self.canvas.create_image(0, 0, image=photo, anchor="nw")
-        else:
-            try:
-                self.canvas.itemconfigure(self.canvas_image_id, image=photo)
-            except tk.TclError:
-                self.canvas_image_id = self.canvas.create_image(0, 0, image=photo, anchor="nw")
-        self.canvas.config(scrollregion=(0, 0, new_width, new_height))
-        self.zoom_factor = target
-        base_scale_x, base_scale_y = self._base_scale
-        self.display_scale = (base_scale_x * target, base_scale_y * target)
-        self._render_overlays()
-        if focus is not None:
-            self._adjust_canvas_view(focus, old_factor, target, new_width, new_height)
+    def _export_lines(self, item: AnnotationItem) -> Optional[Path]:
+        lines = self.store.list()
+        if self.options.export_format == "pagexml":
+            out_dir = self.train_dir / "pagexml"
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_path = out_dir / f"{item.path.stem}.xml"
+            save_pagexml(item.path, lines, out_path)
+            return out_path
+        out_dir = self.train_dir / "lines"
+        save_line_crops(item.path, lines, out_dir)
+        return out_dir
 
-    def _adjust_canvas_view(
-        self,
-        focus: Tuple[float, float],
-        old_factor: float,
-        new_factor: float,
-        new_width: int,
-        new_height: int,
-    ) -> None:
-        if old_factor <= 0:
-            scale_ratio = new_factor
-        else:
-            scale_ratio = new_factor / old_factor
-        new_focus_x = focus[0] * scale_ratio
-        new_focus_y = focus[1] * scale_ratio
-        canvas_width = max(1, self.canvas.winfo_width())
-        canvas_height = max(1, self.canvas.winfo_height())
-        if new_width > canvas_width:
-            left = max(0.0, min(new_focus_x - canvas_width / 2, new_width - canvas_width))
-            self.canvas.xview_moveto(left / new_width)
-        else:
-            self.canvas.xview_moveto(0)
-        if new_height > canvas_height:
-            top = max(0.0, min(new_focus_y - canvas_height / 2, new_height - canvas_height))
-            self.canvas.yview_moveto(top / new_height)
-        else:
-            self.canvas.yview_moveto(0)
-
-    # ------------------------------------------------------------------
-    # Overlay entry handling
-    # ------------------------------------------------------------------
-    def _reset_resize_state(self) -> None:
-        self._resize_overlay_id = None
-        self._resize_original_bbox = None
-        self._resize_original_base_bbox = None
-        self._resize_anchor = None
-        self._resize_press_point = None
-        self._resize_changed = False
-        self._drag_mode = None
-        self._drag_start = None
-        self._pending_click_id = None
-
-    def _determine_resize_anchor(
-        self,
-        bbox: Tuple[float, float, float, float],
-        x: float,
-        y: float,
-    ) -> Tuple[str, str]:
-        left, top, right, bottom = bbox
-        threshold = 12.0
-        if abs(x - left) <= threshold:
-            anchor_x = "left"
-        elif abs(x - right) <= threshold:
-            anchor_x = "right"
-        else:
-            anchor_x = "center"
-
-        if abs(y - top) <= threshold:
-            anchor_y = "top"
-        elif abs(y - bottom) <= threshold:
-            anchor_y = "bottom"
-        else:
-            anchor_y = "center"
-        return anchor_x, anchor_y
-
-    def _on_overlay_press(self, event: tk.Event, overlay_id: int) -> str:
-        if self.mode_var.get() != "select":
-            return ""
-        overlay = self.store.get_overlay(overlay_id)
-        bbox = self._overlay_positions.get(overlay_id)
-        if overlay is None or bbox is None:
-            return ""
-        x, y = self._canvas_coords(event.x, event.y)
-        self._resize_overlay_id = overlay_id
-        self._resize_original_bbox = bbox
-        self._resize_original_base_bbox = overlay.bbox_base
-        self._resize_press_point = (x, y)
-        self._resize_anchor = self._determine_resize_anchor(bbox, x, y)
-        self._resize_changed = False
-        self._drag_mode = "resize"
-        self._drag_start = (x, y)
-        additive = self._event_has_ctrl(event) or self._event_has_shift(event)
-        self.store.select_click(overlay_id, additive=additive)
-        self._pending_click_id = overlay_id
-        return "break"
-
-    def _on_overlay_drag(self, event: tk.Event, overlay_id: int) -> str:
-        if self.mode_var.get() != "select":
-            return ""
-        if self._resize_overlay_id != overlay_id:
-            return ""
-        if self._resize_original_bbox is None or self._resize_anchor is None:
-            return ""
-        x, y = self._canvas_coords(event.x, event.y)
-        left, top, right, bottom = self._resize_original_bbox
-        anchor_x, anchor_y = self._resize_anchor
-        min_size = 4.0
-
-        if anchor_x == "left":
-            new_left = min(x, right - min_size)
-            new_right = right
-        elif anchor_x == "right":
-            new_left = left
-            new_right = max(x, left + min_size)
-        else:
-            press_x = self._resize_press_point[0] if self._resize_press_point else left
-            dx = x - press_x
-            new_left = left + dx
-            new_right = right + dx
-
-        if anchor_y == "top":
-            new_top = min(y, bottom - min_size)
-            new_bottom = bottom
-        elif anchor_y == "bottom":
-            new_top = top
-            new_bottom = max(y, top + min_size)
-        else:
-            press_y = self._resize_press_point[1] if self._resize_press_point else top
-            dy = y - press_y
-            new_top = top + dy
-            new_bottom = bottom + dy
-
-        if anchor_x == "center":
-            width = right - left
-            new_right = new_left + width
-        if anchor_y == "center":
-            height = bottom - top
-            new_bottom = new_top + height
-
-        if new_left > new_right:
-            new_left, new_right = new_right, new_left
-        if new_top > new_bottom:
-            new_top, new_bottom = new_bottom, new_top
-
-        base_bbox = self._to_base((new_left, new_top, new_right, new_bottom))
-        if (
-            self._resize_original_base_bbox is not None
-            and base_bbox == self._resize_original_base_bbox
-        ):
-            return "break"
-        overlay = self.store.get_overlay(overlay_id)
-        if overlay is not None and overlay.bbox_base == base_bbox:
-            return "break"
-        self.store.update_bbox(overlay_id, base_bbox)
-        self._resize_changed = True
-        return "break"
-
-    def _on_overlay_release(self, event: tk.Event, overlay_id: int) -> str:
-        if self.mode_var.get() != "select":
-            self._reset_resize_state()
-            return ""
-        if self._resize_overlay_id != overlay_id:
-            self._reset_resize_state()
-            return ""
-        if self._resize_changed and self._resize_original_base_bbox is not None:
-            overlay = self.store.get_overlay(overlay_id)
-            if overlay is not None:
-                self.store.update_bbox(
-                    overlay_id,
-                    overlay.bbox_base,
-                    commit=True,
-                    previous_bbox=self._resize_original_base_bbox,
-                )
-        self._reset_resize_state()
-        return "break"
-
-    def _on_rect_click(self, event: tk.Event, overlay_id: int) -> None:
-        additive = self._event_has_ctrl(event) or self._event_has_shift(event)
-        self.store.select_click(overlay_id, additive=additive)
-
-    def _on_entry_focus(self, overlay_id: int) -> None:
-        if overlay_id not in self.store.selection:
-            self.store.select_click(overlay_id, additive=False)
-        self.store.request_focus(overlay_id)
-
-    def _on_overlay_entry_changed(self, event: tk.Event) -> None:
-        if self._entry_guard:
-            return
-        entry = event.widget
-        overlay_id = getattr(entry, "_overlay_id", None)
-        if overlay_id is None:
-            return
-        text = entry.get().strip()
-        self.store.update_text(int(overlay_id), text)
-        self._user_modified_transcription = False
-        self._update_combined_transcription()
-
-    def _focus_overlay(self, overlay_id: Optional[int]) -> None:
-        if overlay_id is None:
-            return
-        view = self.overlay_views.get(overlay_id)
-        if view is None:
-            return
-        try:
-            view.entry.focus_set()
-        except tk.TclError:
-            pass
-
-    # ------------------------------------------------------------------
-    # Store event handlers
-    # ------------------------------------------------------------------
-    def _on_store_overlays(self, _value: object) -> None:
-        self._render_overlays()
-        self._update_combined_transcription()
-
-    def _on_store_selection(self, selection: Tuple[int, ...]) -> None:
-        if len(selection) == 1:
-            self.store.request_focus(selection[0])
-            self.store.set_status("Focused overlay selected")
-        elif not selection:
-            self.store.set_status(None)
-        else:
-            self.store.set_status(f"{len(selection)} overlays selected")
-        self._refresh_delete_button()
-
-    def _on_store_focus(self, overlay_id: Optional[int]) -> None:
-        self._focus_overlay(overlay_id)
-
-    def _on_store_status(self, message: Optional[str]) -> None:
-        if hasattr(self, "status_var"):
-            self.status_var.set(message or "")
-
-    # ------------------------------------------------------------------
-    # Undo / redo / deletion
-    # ------------------------------------------------------------------
-    def _delete_selected(self) -> None:
-        selection = list(self.store.selection)
-        if not selection:
-            return
-        self.store.remove_by_ids(selection)
-        self.store.set_status("Deleted selected overlays")
-
-    def _on_delete_selected(self, event: Optional[tk.Event]) -> str:
-        self._delete_selected()
-        return "break"
-
-    def _on_undo(self, event: Optional[tk.Event]) -> str:
-        if self.store.undo():
-            return "break"
-        return ""
-
-    def _on_overlay_modified(self, _event: Optional[tk.Event]) -> None:
-        if hasattr(self, "store"):
-            for legacy in getattr(self, "overlay_items", []):
-                text = legacy.entry.get().strip()
-                overlay = self.store.get_overlay(legacy.overlay_id)
-                if overlay is None or overlay.text.strip() == text:
-                    continue
-                self.store.update_text(legacy.overlay_id, text)
-        self._user_modified_transcription = False
-        self._update_combined_transcription()
-
-    def _on_redo(self, event: Optional[tk.Event]) -> str:
-        if self.store.redo():
-            return "break"
-        return ""
-
-    # ------------------------------------------------------------------
-    # Transcription synchronisation
-    # ------------------------------------------------------------------
-    def _on_transcription_modified(self, event: tk.Event | None) -> None:
-        if not self._setting_transcription:
-            self._user_modified_transcription = True
-            self._apply_transcription_to_overlays()
-
-    def _apply_transcription_to_overlays(self) -> None:
-        if self._setting_transcription:
-            return
-        text = self.entry_widget.get("1.0", tk.END)
-        tokens = re.findall(r"\S+", text)
-        if not hasattr(self, "store"):
-            for index, entry in enumerate(getattr(self, "overlay_entries", [])):
-                value = tokens[index] if index < len(tokens) else ""
-                try:
-                    entry.delete(0, tk.END)
-                except Exception:  # pragma: no cover - test doubles
-                    entry.delete(0)
-                if value:
-                    entry.insert(0, value)
-            self._user_modified_transcription = False
-            return
-
-        overlays = self.store.list_overlays()
-        for index, overlay in enumerate(overlays):
-            value = tokens[index] if index < len(tokens) else ""
-            value = value.strip()
-            if overlay.text.strip() == value:
-                continue
-            self.store.update_text(overlay.id, value)
-        self._user_modified_transcription = False
-        self._update_combined_transcription()
-
-    def _update_combined_transcription(self) -> None:
-        if self._user_modified_transcription:
-            return
-        text = self.store.compose_text()
-        self._set_transcription(text)
-
-    def _set_transcription(self, value: str) -> None:
-        self._setting_transcription = True
-        self.entry_widget.delete("1.0", tk.END)
-        if value:
-            self.entry_widget.insert("1.0", value)
-        self._setting_transcription = False
-        self._user_modified_transcription = False
-
-    def _get_transcription_text(self) -> str:
-        return self.entry_widget.get("1.0", tk.END).strip()
-
-    # ------------------------------------------------------------------
-    # OCR helpers
-    # ------------------------------------------------------------------
-    def _extract_tokens(self, image: Image.Image) -> List[OcrToken]:
-        ocr_image: Optional[Image.Image] = None
-        try:
-            ocr_image = image.copy()
-            if ocr_image.mode not in {"RGB", "L"}:
-                converted = ocr_image.convert("RGB")
-                ocr_image.close()
-                ocr_image = converted
-            data = pytesseract.image_to_data(
-                ocr_image,
-                config="--psm 6",
-                output_type=Output.DICT,
-            )
-        except pytesseract.TesseractNotFoundError as exc:
-            logging.warning("Tesseract not found: %s", exc)
-            return []
-        except pytesseract.TesseractError as exc:
-            logging.warning("Tesseract error: %s", exc)
-            return []
-        finally:
-            if ocr_image is not None:
-                ocr_image.close()
-
-        if not data or "text" not in data:
-            return []
-
-        tokens: List[OcrToken] = []
-        length = len(data.get("text", []))
-        for index in range(length):
-            text = (data["text"][index] or "").strip()
-            if not text:
-                continue
-            try:
-                left = int(data.get("left", [0])[index])
-                top = int(data.get("top", [0])[index])
-                width = int(data.get("width", [0])[index])
-                height = int(data.get("height", [0])[index])
-                page = int(data.get("page_num", [1])[index])
-                block = int(data.get("block_num", [0])[index])
-                paragraph = int(data.get("par_num", [0])[index])
-                line = int(data.get("line_num", [0])[index])
-                word = int(data.get("word_num", [index + 1])[index]) or (index + 1)
-            except (TypeError, ValueError):
-                continue
-
-            bbox = (left, top, left + width, top + height)
-            order_key: TokenOrder = (page, block, paragraph, line, word)
-            paragraph_key: ParagraphKey = (page, block, paragraph)
-            line_key: LineKey = (page, block, line)
-            tokens.append(
-                OcrToken(
-                    text=text,
-                    bbox=bbox,
-                    order_key=order_key,
-                    paragraph_key=paragraph_key,
-                    line_key=line_key,
-                )
-            )
-
-        tokens.sort(key=lambda token: token.order_key)
-        return tokens
-
-    def _compose_text_from_tokens(self, tokens: Sequence[OcrToken]) -> str:
-        if not tokens:
-            return ""
-
-        lines: Dict[LineKey, List[Tuple[TokenOrder, str]]] = {}
-        line_orders: Dict[LineKey, Tuple[int, int, int, int]] = {}
-        paragraph_keys: Dict[LineKey, ParagraphKey] = {}
-        for token in tokens:
-            line_key = token.line_key
-            lines.setdefault(line_key, []).append((token.order_key, token.text))
-            line_orders.setdefault(line_key, token.order_key[:-1])
-            paragraph_keys.setdefault(line_key, token.paragraph_key)
-
-        ordered_lines: List[Tuple[Tuple[int, int, int, int], ParagraphKey, str]] = []
-        for line_key, words in lines.items():
-            ordered_words = [
-                word
-                for _, word in sorted(
-                    words,
-                    key=lambda item: item[0],
-                )
-            ]
-            ordered_lines.append(
-                (
-                    line_orders[line_key],
-                    paragraph_keys[line_key],
-                    " ".join(ordered_words),
-                )
-            )
-
-        composed: List[str] = []
-        previous_paragraph: Optional[ParagraphKey] = None
-        for _, paragraph_key, text in sorted(ordered_lines, key=lambda item: item[0]):
-            if previous_paragraph is not None and paragraph_key != previous_paragraph:
-                composed.append("")
-            composed.append(text)
-            previous_paragraph = paragraph_key
-        return "\n".join(composed)
-
-    # ------------------------------------------------------------------
-    # Persistence helpers
-    # ------------------------------------------------------------------
-    def _save_annotation(self, image_path: Path, label: str) -> Path:
-        slug = self._slugify(label)
-        output_path = self.train_dir / f"{image_path.stem}-{slug}.png"
-        with Image.open(image_path) as image:
-            image = _prepare_image(image)
-            image.save(output_path)
-        return output_path
-
-    def _append_log(
-        self,
-        path: Path,
-        label: str,
-        status: str,
-        saved_path: Optional[Path],
-    ) -> None:
+    def _append_log(self, path: Path, label: str, status: str, saved_path: Optional[Path]) -> None:
         if self.log_path is None:
             return
         is_new = not self.log_path.exists()
@@ -1282,29 +376,209 @@ class AnnotationApp:
                 writer.writerow(["filename", "label", "status", "saved_path"])
             writer.writerow([path.name, label, status, saved_path.name if saved_path else ""])
 
-    def _suggest_label(self, path: Path) -> str:
-        cleaned = [c if c.isalnum() else " " for c in path.stem]
-        text = re.sub(r"\s+", " ", "".join(cleaned)).strip()
-        return text
+    def _clear_canvas(self) -> None:
+        self.canvas.delete("all")
+        for view in self.line_views.values():
+            view.entry.destroy()
+        self.line_views.clear()
 
-    def _slugify(self, value: str) -> str:
-        cleaned = [c if c.isalnum() else "-" for c in value.strip().lower()]
-        slug = "".join(cleaned)
-        slug = re.sub("-+", "-", slug).strip("-")
-        if len(slug) > 60:
-            slug = slug[:60].rstrip("-")
-        return slug or "sample"
+    # ------------------------------------------------------------------
+    # Canvas interaction
+    # ------------------------------------------------------------------
+    def _on_canvas_press(self, event: tk.Event) -> None:
+        if self.mode_var.get() == "draw":
+            self._start_drawing(event)
+            return
+        base_point = to_base_point((event.x, event.y), self.display_scale)
+        line_id = self.store.hit_test(base_point[0], base_point[1], tol=5.0)
+        if line_id is not None:
+            additive = bool(event.state & (CONTROL_MASK | SHIFT_MASK))
+            self.store.do(SetSelection({line_id}, additive=additive))
+            self._refresh_lines()
+            self._focus_selected()
+        elif event.state & (CONTROL_MASK | SHIFT_MASK):
+            self._start_marquee(event)
+        else:
+            self.store.select_only(set())
+            self._refresh_lines()
 
+    def _on_canvas_drag(self, event: tk.Event) -> None:
+        if self._drawing_points:
+            self._update_drawing(event)
+        elif hasattr(self, "_marquee_start"):
+            self._update_marquee(event)
 
-def _train_model(*args, **kwargs):  # pragma: no cover - deferred import
+    def _on_canvas_release(self, event: tk.Event) -> None:
+        if self._drawing_points:
+            return
+        if hasattr(self, "_marquee_start"):
+            self._finish_marquee(event)
+
+    def _start_drawing(self, event: tk.Event) -> None:
+        point = to_base_point((event.x, event.y), self.display_scale)
+        self._drawing_points = [point]
+        display_point = to_display_point(point, self.display_scale)
+        self._drawing_canvas_item = self.canvas.create_line(*display_point, *display_point, fill="orange", width=2)
+        self.status_var.set("Drawing baseline: press Enter to finish, Esc to cancel")
+
+    def _update_drawing(self, event: tk.Event) -> None:
+        point = to_base_point((event.x, event.y), self.display_scale)
+        if self._drawing_points and self._drawing_points[-1] == point:
+            return
+        self._drawing_points.append(point)
+        display_points = []
+        for pt in self._drawing_points:
+            display_points.extend(to_display_point(pt, self.display_scale))
+        if self._drawing_canvas_item is not None:
+            self.canvas.coords(self._drawing_canvas_item, *display_points)
+
+    def _finish_drawing(self) -> None:
+        if len(self._drawing_points) < 2:
+            self._cancel_drawing()
+            return
+        baseline = list(self._drawing_points)
+        self.store.do(AddLine(baseline))
+        self._cancel_drawing()
+        self._refresh_lines()
+        self.status_var.set("Added manual line")
+
+    def _cancel_drawing(self) -> None:
+        if self._drawing_canvas_item is not None:
+            self.canvas.delete(self._drawing_canvas_item)
+        self._drawing_canvas_item = None
+        self._drawing_points = []
+        self.status_var.set("Drawing cancelled")
+
+    def _on_return(self, event: tk.Event) -> None:
+        if self._drawing_points:
+            self._finish_drawing()
+
+    def _start_marquee(self, event: tk.Event) -> None:
+        self._marquee_start = (event.x, event.y)
+        self._marquee_rect = self.canvas.create_rectangle(event.x, event.y, event.x, event.y, outline="blue", dash=(2, 2))
+
+    def _update_marquee(self, event: tk.Event) -> None:
+        if not hasattr(self, "_marquee_start"):
+            return
+        x0, y0 = self._marquee_start
+        if self._marquee_rect is not None:
+            self.canvas.coords(self._marquee_rect, x0, y0, event.x, event.y)
+
+    def _finish_marquee(self, event: tk.Event) -> None:
+        x0, y0 = self._marquee_start
+        x1, y1 = event.x, event.y
+        if self._marquee_rect is not None:
+            self.canvas.delete(self._marquee_rect)
+        del self._marquee_start
+        self._marquee_rect = None
+        if abs(x1 - x0) < 5 or abs(y1 - y0) < 5:
+            return
+        base_bbox = to_base_bbox((x0, y0, x1, y1), self.display_scale)
+        hits = self.store.bbox_intersect(base_bbox)
+        self.store.do(SetSelection(hits, additive=True))
+        self._refresh_lines()
+        self.status_var.set(f"Selected {len(hits)} lines")
+
+    # ------------------------------------------------------------------
+    # Line rendering
+    # ------------------------------------------------------------------
+    def _refresh_lines(self) -> None:
+        # Remove previous line drawings but keep background image
+        for view in list(self.line_views.values()):
+            if view.canvas_item is not None:
+                self.canvas.delete(view.canvas_item)
+            view.entry.destroy()
+        self.line_views.clear()
+
+        for line in self.store.list():
+            display_points: List[float] = []
+            for point in line.baseline:
+                display_points.extend(to_display_point(point, self.display_scale))
+            colour = "#2563eb" if line.selected else "#f97316"
+            canvas_item = self.canvas.create_line(*display_points, fill=colour, width=2)
+            text_var = tk.StringVar(value=line.text)
+            entry = tk.Entry(self.lines_frame, textvariable=text_var, width=80)
+            entry.pack(fill="x", pady=2)
+            entry.bind("<FocusOut>", lambda event, line_id=line.id, var=text_var: self._commit_entry(line_id, var))
+            entry.bind("<Return>", lambda event, line_id=line.id, var=text_var: self._commit_entry(line_id, var))
+            entry.bind("<Key>", lambda event: self._on_entry_key())
+            if line.selected:
+                entry.configure(background="#dbeafe")
+            self.line_views[line.id] = LineView(line.id, canvas_item, text_var, entry)
+
+        self.delete_button.config(state=tk.NORMAL if self.store.selection() else tk.DISABLED)
+        self._update_transcription()
+
+    def _commit_entry(self, line_id: int, var: tk.StringVar) -> None:
+        try:
+            text = var.get()
+        except tk.TclError:
+            return
+        line = next((line for line in self.store.list() if line.id == line_id), None)
+        if line is None or line.text == text:
+            return
+        self.store.do(UpdateText(line_id, text))
+        self._refresh_lines()
+        self.status_var.set("Updated text")
+
+    def _on_entry_key(self) -> None:
+        self._user_modified_transcription = True
+
+    def _focus_selected(self) -> None:
+        selected = self.store.selection()
+        if len(selected) == 1:
+            line_id = next(iter(selected))
+            view = self.line_views.get(line_id)
+            if view is not None:
+                view.entry.focus_set()
+
+    # ------------------------------------------------------------------
+    # Editing helpers
+    # ------------------------------------------------------------------
+    def _delete_selected(self) -> None:
+        selection = self.store.selection()
+        if not selection:
+            return
+        self.store.do(RemoveLines(selection))
+        self._refresh_lines()
+        self.status_var.set("Removed selected lines")
+
+    def _on_delete_selected(self, event: Optional[tk.Event]) -> None:
+        self._delete_selected()
+
+    def _on_undo(self, event: Optional[tk.Event]) -> None:
+        if self.store.undo():
+            self._refresh_lines()
+            self.status_var.set("Undo")
+
+    def _on_redo(self, event: Optional[tk.Event]) -> None:
+        if self.store.redo():
+            self._refresh_lines()
+            self.status_var.set("Redo")
+
+    def _on_transcription_modified(self, event: tk.Event) -> None:
+        if event.keysym in {"Shift_L", "Shift_R", "Control_L", "Control_R"}:
+            return
+        self._user_modified_transcription = True
+
+    def _update_transcription(self) -> None:
+        if self._user_modified_transcription:
+            return
+        text = self.store.compose_text()
+        self._setting_transcription = True
+        self.entry_widget.delete("1.0", tk.END)
+        self.entry_widget.insert("1.0", text)
+        self._setting_transcription = False
+
+def _train_model(*args, **kwargs):  # pragma: no cover
     if __package__:
         from .training import train_model as _impl
-    else:  # pragma: no cover - fallback for test imports
-        from training import train_model as _impl
+    else:
+        from training import train_model as _impl  # type: ignore
     return _impl(*args, **kwargs)
 
 
-@dataclass(slots=True)
+@dataclass
 class AnnotationAutoTrainConfig:
     auto_train: int
     output_model: str
@@ -1314,50 +588,28 @@ class AnnotationAutoTrainConfig:
     tessdata_dir: Optional[Path] = None
 
 
+@dataclass
 class AnnotationTrainer:
-    """Schedule background training runs as annotations are confirmed."""
-
-    def __init__(
-        self,
-        master: tk.Misc,
-        *,
-        train_dir: Path,
-        config: AnnotationAutoTrainConfig,
-    ) -> None:
-        if config.auto_train <= 0:
-            raise ValueError("auto_train must be a positive integer")
-        self.master = master
-        self.train_dir = Path(train_dir)
-        self.config = config
-        self._pending: deque[Path] = deque()
-        self._seen_samples: List[Path] = []
-        self._running = False
-
-    @property
-    def seen_samples(self) -> List[Path]:
-        return list(self._seen_samples)
+    master: tk.Misc
+    train_dir: Path
+    config: AnnotationAutoTrainConfig
+    _pending: Sequence[Path] = field(default_factory=list, init=False)
 
     def __call__(self, sample_path: Path) -> None:
         path = Path(sample_path)
-        self._pending.append(path)
-        self._seen_samples.append(path)
-        self.master.after(0, self._maybe_train)
+        self._pending = list(self._pending) + [path]
+        if len(self._pending) >= self.config.auto_train:
+            self.master.after(0, self._maybe_train)
 
     def _maybe_train(self) -> None:
-        if self._running:
-            return
         if len(self._pending) < self.config.auto_train:
             return
-
-        batch = [self._pending.popleft() for _ in range(self.config.auto_train)]
-        self._running = True
+        batch = list(self._pending)[: self.config.auto_train]
+        self._pending = self._pending[self.config.auto_train :]
 
         def worker() -> None:
             try:
-                logging.info(
-                    "Auto-training triggered by %d new annotations.",
-                    len(batch),
-                )
+                logging.info("Auto-training triggered by %d new annotations", len(batch))
                 model_path = _train_model(
                     self.train_dir,
                     self.config.output_model,
@@ -1367,44 +619,34 @@ class AnnotationTrainer:
                     max_iterations=self.config.max_iterations,
                 )
                 logging.info("Updated model saved to %s", model_path)
-            except Exception:  # pragma: no cover - logging side effects
-                logging.exception("Auto-training failed.")
-            finally:
-                self._running = False
-                self.master.after(0, self._maybe_train)
+            except Exception:
+                logging.exception("Auto-training failed")
 
-        thread = threading.Thread(target=worker, daemon=True)
-        thread.start()
+        threading.Thread(target=worker, daemon=True).start()
 
 
 def annotate_images(
     sources: Iterable[Path],
     train_dir: Path,
     *,
+    options: Optional[AnnotationOptions] = None,
     log_path: Optional[Path] = None,
     auto_train_config: Optional[AnnotationAutoTrainConfig] = None,
 ) -> None:
-    """Launch the annotation UI for the provided image paths."""
-
     items = [AnnotationItem(Path(path)) for path in sources]
     if not items:
         raise ValueError("No images found to annotate.")
 
     try:
         root = tk.Tk()
-    except tk.TclError as exc:  # pragma: no cover - depends on environment
+    except tk.TclError as exc:
         raise RuntimeError(
-            "Tkinter could not be initialised. Ensure a display is available or "
-            "use a system package such as python3-tk."
+            "Tkinter could not be initialised. Ensure a display is available or install python3-tk."
         ) from exc
 
     callback = None
     if auto_train_config is not None:
-        callback = AnnotationTrainer(
-            root,
-            train_dir=train_dir,
-            config=auto_train_config,
-        )
+        callback = AnnotationTrainer(root, train_dir=Path(train_dir), config=auto_train_config)
 
-    app = AnnotationApp(root, items, train_dir, log_path, on_sample_saved=callback)
+    app = AnnotationApp(root, items, Path(train_dir), options=options, log_path=log_path, on_sample_saved=callback)
     root.mainloop()

--- a/src/exporters.py
+++ b/src/exporters.py
@@ -1,0 +1,97 @@
+"""Export helpers for Kraken-compatible datasets."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List
+from xml.etree import ElementTree as ET
+
+from PIL import Image
+
+from .line_store import Line
+
+
+def _sorted_lines(lines: Iterable[Line]) -> List[Line]:
+    return sorted(lines, key=lambda line: line.order_key)
+
+
+def save_line_crops(image_path: Path, lines: Iterable[Line], out_dir: Path) -> None:
+    """Save cropped line images and ``.gt.txt`` files for Kraken training."""
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with Image.open(image_path) as image:
+        base = image.convert("L")
+        width, height = base.size
+        padding = 4
+        for index, line in enumerate(_sorted_lines(lines), start=1):
+            left, top, right, bottom = line.bbox
+            crop_box = (
+                max(0, int(left) - padding),
+                max(0, int(top) - padding),
+                min(width, int(right) + padding),
+                min(height, int(bottom) + padding),
+            )
+            crop = base.crop(crop_box)
+            base_name = f"{image_path.stem}_line{index:02d}"
+            image_out = out_dir / f"{base_name}.png"
+            crop.save(image_out)
+            text_out = out_dir / f"{base_name}.gt.txt"
+            text_out.write_text(line.text or "", encoding="utf8")
+
+
+def _format_points(points: Iterable[tuple[float, float]]) -> str:
+    return " ".join(f"{int(x)},{int(y)}" for x, y in points)
+
+
+def save_pagexml(image_path: Path, lines: Iterable[Line], out_path: Path) -> None:
+    """Write PAGE-XML annotations for the provided ``lines``."""
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with Image.open(image_path) as image:
+        width, height = image.size
+
+    namespace = "http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"
+    ET.register_namespace("", namespace)
+    root = ET.Element("{namespace}PcGts".format(namespace=namespace))
+
+    metadata = ET.SubElement(root, "{namespace}Metadata".format(namespace=namespace))
+    ET.SubElement(metadata, "{namespace}Creator".format(namespace=namespace)).text = "Standup-OCR"
+    ET.SubElement(metadata, "{namespace}Created".format(namespace=namespace)).text = datetime.utcnow().isoformat()
+
+    page = ET.SubElement(
+        root,
+        "{namespace}Page".format(namespace=namespace),
+        {
+            "imageFilename": image_path.name,
+            "imageWidth": str(width),
+            "imageHeight": str(height),
+        },
+    )
+    region = ET.SubElement(page, "{namespace}TextRegion".format(namespace=namespace), {"id": "r1"})
+
+    for index, line in enumerate(_sorted_lines(lines), start=1):
+        line_id = f"l{line.id or index}"
+        text_line = ET.SubElement(region, "{namespace}TextLine".format(namespace=namespace), {"id": line_id})
+        left, top, right, bottom = line.bbox
+        coords = [
+            (left, top),
+            (right, top),
+            (right, bottom),
+            (left, bottom),
+        ]
+        ET.SubElement(
+            text_line,
+            "{namespace}Coords".format(namespace=namespace),
+            {"points": _format_points(coords)},
+        )
+        ET.SubElement(
+            text_line,
+            "{namespace}Baseline".format(namespace=namespace),
+            {"points": _format_points(line.baseline)},
+        )
+        text_equiv = ET.SubElement(text_line, "{namespace}TextEquiv".format(namespace=namespace))
+        unicode_el = ET.SubElement(text_equiv, "{namespace}Unicode".format(namespace=namespace))
+        unicode_el.text = line.text or ""
+
+    tree = ET.ElementTree(root)
+    tree.write(out_path, encoding="utf-8", xml_declaration=True)

--- a/src/kraken_adapter.py
+++ b/src/kraken_adapter.py
@@ -1,0 +1,148 @@
+"""Thin wrappers around Kraken/ketos functionality."""
+from __future__ import annotations
+"""Optional integration with Kraken (ketos) for segmentation and OCR."""
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from PIL import Image
+
+Logger = logging.getLogger(__name__)
+
+
+def is_available() -> bool:
+    try:
+        import kraken  # type: ignore  # pragma: no cover
+
+        return True
+    except Exception:  # pragma: no cover - intentionally broad for user feedback
+        return False
+
+
+def _require_kraken() -> None:
+    if not is_available():
+        raise RuntimeError(
+            "Kraken is not available. Install it with 'pip install kraken[serve]' "
+            "and ensure the 'kraken' and 'ketos' commands are on your PATH."
+        )
+
+
+def segment_lines(image_path: Path, out_pagexml: Optional[Path] = None) -> List[List[Tuple[float, float]]]:
+    """Run Kraken's baseline segmenter and return a list of baselines.
+
+    The function favours the Python API (``kraken.blla``) but falls back to the
+    command line if necessary. When ``out_pagexml`` is provided, the PAGE-XML
+    produced by Kraken is saved to that location when possible.
+    """
+
+    _require_kraken()
+    try:
+        from kraken import blla  # type: ignore
+    except Exception as exc:  # pragma: no cover - only triggered when API fails
+        raise RuntimeError("Kraken is installed but the baseline API is unavailable") from exc
+
+    with Image.open(image_path) as image:
+        try:
+            segmentation = blla.segment(image.convert("L"))  # type: ignore[attr-defined]
+        except Exception as exc:  # pragma: no cover - segmentation errors only at runtime
+            raise RuntimeError(f"Kraken segmentation failed: {exc}") from exc
+
+    baselines: List[List[Tuple[float, float]]] = []
+    for line in segmentation.get("lines", []):
+        baseline = line.get("baseline")
+        if not baseline:
+            continue
+        baselines.append([(float(x), float(y)) for x, y in baseline])
+
+    if out_pagexml is not None:
+        try:
+            from kraken.serialization import serialize  # type: ignore
+
+            xml_bytes = serialize(segmentation=segmentation)
+            out_pagexml.write_bytes(xml_bytes)
+        except Exception as exc:  # pragma: no cover - serialisation is best-effort
+            Logger.warning("Failed to serialise PAGE-XML via Kraken: %s", exc)
+
+    return baselines
+
+
+def train(
+    dataset_dir: Path,
+    model_out: Path,
+    epochs: int = 50,
+    val_split: float = 0.1,
+    base_model: Optional[Path] = None,
+) -> Path:
+    """Call ``ketos train`` with the given dataset directory.
+
+    The directory should contain line images with ``.gt.txt`` files or PAGE-XML
+    documents as required by Kraken. This helper constructs a basic training
+    command but leaves advanced options to the user via manual invocation.
+    """
+
+    _require_kraken()
+    ketos = shutil.which("ketos")
+    if ketos is None:
+        raise RuntimeError(
+            "The 'ketos' command was not found. Install Kraken with 'pip install kraken[serve]' "
+            "and ensure your virtual environment's bin directory is on PATH."
+        )
+
+    cmd = [
+        ketos,
+        "train",
+        "--output",
+        str(model_out),
+        "--epochs",
+        str(epochs),
+        "--validation",
+        str(val_split),
+    ]
+    if base_model is not None:
+        cmd.extend(["--load", str(base_model)])
+    cmd.append(str(dataset_dir))
+
+    Logger.info("Running ketos: %s", " ".join(cmd))
+    try:
+        subprocess.run(cmd, check=True)
+    except FileNotFoundError as exc:  # pragma: no cover - subprocess failure only at runtime
+        raise RuntimeError(f"ketos executable not found: {exc}") from exc
+    except subprocess.CalledProcessError as exc:  # pragma: no cover
+        raise RuntimeError(f"ketos train failed with exit code {exc.returncode}") from exc
+
+    return model_out
+
+
+def ocr(image_path: Path, model_path: Path, out_txt: Path) -> None:
+    """Run ``kraken ocr`` on ``image_path`` and write raw text to ``out_txt``."""
+
+    _require_kraken()
+    kraken_cli = shutil.which("kraken")
+    if kraken_cli is None:
+        raise RuntimeError(
+            "The 'kraken' command was not found. Install Kraken with 'pip install kraken[serve]' "
+            "and ensure it's available on PATH."
+        )
+
+    out_txt.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        kraken_cli,
+        "-i",
+        str(image_path),
+        str(out_txt),
+        "binarize",
+        "segment",
+        "ocr",
+        "-m",
+        str(model_path),
+    ]
+    Logger.info("Running kraken OCR: %s", " ".join(cmd))
+    try:
+        subprocess.run(cmd, check=True)
+    except FileNotFoundError as exc:  # pragma: no cover
+        raise RuntimeError(f"kraken executable not found: {exc}") from exc
+    except subprocess.CalledProcessError as exc:  # pragma: no cover
+        raise RuntimeError(f"kraken ocr failed with exit code {exc.returncode}") from exc

--- a/src/line_store.py
+++ b/src/line_store.py
@@ -1,0 +1,340 @@
+"""State container for baseline-based line annotations."""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Dict, Iterable, List, Optional, Protocol, Sequence, Set, Tuple
+
+Point = Tuple[float, float]
+BBox = Tuple[int, int, int, int]
+TokenOrder = Tuple[int, int, int, int, int]
+
+
+@dataclass
+class Line:
+    """Representation of a segmented text line."""
+
+    id: int
+    baseline: List[Point]
+    bbox: BBox
+    text: str
+    order_key: TokenOrder
+    selected: bool = False
+    is_manual: bool = False
+
+
+class Command(Protocol):
+    """Protocol describing undoable commands."""
+
+    def do(self, store: "LineStore") -> None:
+        ...
+
+    def undo(self, store: "LineStore") -> None:
+        ...
+
+
+class LineStore:
+    """Mutable store with undo/redo support for :class:`Line` objects."""
+
+    def __init__(self) -> None:
+        self._lines: Dict[int, Line] = {}
+        self._order: List[int] = []
+        self._selection: Set[int] = set()
+        self._next_id: int = 1
+        self._order_counter: int = 0
+        self._undo_stack: List[Command] = []
+        self._redo_stack: List[Command] = []
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    # ------------------------------------------------------------------
+    def set_lines(self, lines: List[Line]) -> None:
+        """Replace the store content with ``lines``.
+
+        The provided line instances are copied to avoid outside mutation.
+        """
+
+        self._lines.clear()
+        self._order.clear()
+        self._selection.clear()
+        for line in lines:
+            line_copy = replace(line, baseline=list(line.baseline), selected=line.selected)
+            self._lines[line_copy.id] = line_copy
+            self._order.append(line_copy.id)
+            self._selection.discard(line_copy.id)
+            if line_copy.selected:
+                self._selection.add(line_copy.id)
+        if self._order:
+            self._next_id = max(self._order) + 1
+        else:
+            self._next_id = 1
+        if self._lines:
+            self._order_counter = max(line.order_key[-1] for line in self._lines.values()) + 1
+        else:
+            self._order_counter = 0
+        self._undo_stack.clear()
+        self._redo_stack.clear()
+
+    def _compute_bbox(self, baseline: Iterable[Point]) -> BBox:
+        xs: List[float] = []
+        ys: List[float] = []
+        for x, y in baseline:
+            xs.append(x)
+            ys.append(y)
+        if not xs or not ys:
+            raise ValueError("Baseline must contain at least one point.")
+        left = int(min(xs))
+        top = int(min(ys))
+        right = int(max(xs)) + 1
+        bottom = int(max(ys)) + 1
+        if left == right:
+            right += 1
+        if top == bottom:
+            bottom += 1
+        return left, top, right, bottom
+
+    def add_line(self, baseline: List[Point], is_manual: bool) -> int:
+        if len(baseline) < 2:
+            raise ValueError("Baseline must have at least two points.")
+        bbox = self._compute_bbox(baseline)
+        line_id = self._next_id
+        self._next_id += 1
+        order = (0, 0, 0, 0, self._order_counter)
+        self._order_counter += 1
+        line = Line(
+            id=line_id,
+            baseline=list(baseline),
+            bbox=bbox,
+            text="",
+            order_key=order,
+            selected=False,
+            is_manual=is_manual,
+        )
+        self._lines[line_id] = line
+        self._order.append(line_id)
+        return line_id
+
+    def update_text(self, id_: int, text: str) -> None:
+        if id_ not in self._lines:
+            raise KeyError(id_)
+        line = self._lines[id_]
+        self._lines[id_] = replace(line, text=text)
+
+    def remove(self, ids: Set[int]) -> List[Line]:
+        removed: List[Line] = []
+        remaining_order: List[int] = []
+        for line_id in self._order:
+            if line_id in ids:
+                line = self._lines.pop(line_id, None)
+                if line is not None:
+                    removed.append(line)
+                self._selection.discard(line_id)
+            else:
+                remaining_order.append(line_id)
+        self._order = remaining_order
+        return removed
+
+    def reinsert(self, lines: Iterable[Line]) -> None:
+        for line in lines:
+            if line.id in self._lines:
+                continue
+            self._lines[line.id] = replace(
+                line,
+                baseline=list(line.baseline),
+                selected=False,
+            )
+            self._order.append(line.id)
+            if line.order_key[-1] >= self._order_counter:
+                self._order_counter = line.order_key[-1] + 1
+            if line.id >= self._next_id:
+                self._next_id = line.id + 1
+        self._order.sort(key=lambda idx: self._lines[idx].order_key)
+
+    # ------------------------------------------------------------------
+    # Selection helpers
+    # ------------------------------------------------------------------
+    def select_only(self, ids: Set[int]) -> None:
+        valid = {line_id for line_id in ids if line_id in self._lines}
+        self._selection = valid
+        for line in self._lines.values():
+            line.selected = line.id in valid
+
+    def toggle(self, id_: int) -> None:
+        if id_ not in self._lines:
+            return
+        if id_ in self._selection:
+            self._selection.remove(id_)
+            self._lines[id_].selected = False
+        else:
+            self._selection.add(id_)
+            self._lines[id_].selected = True
+
+    def hit_test(self, x: float, y: float, tol: float = 3.0) -> Optional[int]:
+        best_id: Optional[int] = None
+        best_distance = float("inf")
+        for line_id in self._order:
+            line = self._lines[line_id]
+            distance = _distance_to_polyline(x, y, line.baseline)
+            if distance < tol and distance < best_distance:
+                best_distance = distance
+                best_id = line_id
+        return best_id
+
+    def bbox_intersect(self, bbox: BBox) -> Set[int]:
+        left, top, right, bottom = bbox
+        hits: Set[int] = set()
+        for line_id in self._order:
+            lb, tb, rb, bb = self._lines[line_id].bbox
+            if rb < left or lb > right or bb < top or tb > bottom:
+                continue
+            hits.add(line_id)
+        return hits
+
+    # ------------------------------------------------------------------
+    # Information access
+    # ------------------------------------------------------------------
+    def compose_text(self) -> str:
+        ordered = sorted(self._lines.values(), key=lambda line: line.order_key)
+        return "\n".join(line.text for line in ordered)
+
+    def list(self) -> List[Line]:
+        return [self._lines[idx] for idx in sorted(self._order, key=lambda i: self._lines[i].order_key)]
+
+    def selection(self) -> Set[int]:
+        return set(self._selection)
+
+    # ------------------------------------------------------------------
+    # Undo/redo integration
+    # ------------------------------------------------------------------
+    def do(self, cmd: Command) -> None:
+        cmd.do(self)
+        self._undo_stack.append(cmd)
+        self._redo_stack.clear()
+
+    def undo(self) -> bool:
+        if not self._undo_stack:
+            return False
+        cmd = self._undo_stack.pop()
+        cmd.undo(self)
+        self._redo_stack.append(cmd)
+        return True
+
+    def redo(self) -> bool:
+        if not self._redo_stack:
+            return False
+        cmd = self._redo_stack.pop()
+        cmd.do(self)
+        self._undo_stack.append(cmd)
+        return True
+
+
+# ----------------------------------------------------------------------
+# Commands
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class AddLine(Command):
+    baseline: List[Point]
+    is_manual: bool = True
+    new_id: Optional[int] = None
+
+    def do(self, store: LineStore) -> None:
+        self.new_id = store.add_line(self.baseline, self.is_manual)
+
+    def undo(self, store: LineStore) -> None:
+        if self.new_id is None:
+            return
+        store.remove({self.new_id})
+
+
+@dataclass
+class RemoveLines(Command):
+    ids: Set[int]
+    stash: Optional[List[Line]] = None
+    previous_selection: Optional[Set[int]] = None
+
+    def do(self, store: LineStore) -> None:
+        self.previous_selection = store.selection()
+        self.stash = store.remove(self.ids)
+
+    def undo(self, store: LineStore) -> None:
+        if not self.stash:
+            return
+        store.reinsert(self.stash)
+        if self.previous_selection is not None:
+            store.select_only(self.previous_selection)
+
+
+@dataclass
+class UpdateText(Command):
+    id_: int
+    new: str
+    old: Optional[str] = None
+
+    def do(self, store: LineStore) -> None:
+        if self.old is None:
+            line = next((line for line in store.list() if line.id == self.id_), None)
+            if line is None:
+                raise KeyError(self.id_)
+            self.old = line.text
+        store.update_text(self.id_, self.new)
+
+    def undo(self, store: LineStore) -> None:
+        if self.old is None:
+            return
+        store.update_text(self.id_, self.old)
+
+
+@dataclass
+class SetSelection(Command):
+    ids: Set[int]
+    additive: bool = False
+    prev: Optional[Set[int]] = None
+
+    def do(self, store: LineStore) -> None:
+        current = store.selection()
+        self.prev = current
+        if self.additive:
+            target = set(current)
+            for line_id in self.ids:
+                if line_id in target:
+                    target.remove(line_id)
+                else:
+                    target.add(line_id)
+            store.select_only(target)
+        else:
+            store.select_only(self.ids)
+
+    def undo(self, store: LineStore) -> None:
+        if self.prev is None:
+            return
+        store.select_only(self.prev)
+
+
+def _distance_to_polyline(x: float, y: float, points: Sequence[Point]) -> float:
+    if len(points) == 0:
+        return float("inf")
+    best = float("inf")
+    px, py = points[0]
+    for idx in range(1, len(points)):
+        qx, qy = points[idx]
+        distance = _distance_point_segment(x, y, px, py, qx, qy)
+        if distance < best:
+            best = distance
+        px, py = qx, qy
+    return best
+
+
+def _distance_point_segment(
+    x: float, y: float, x1: float, y1: float, x2: float, y2: float
+) -> float:
+    # Based on projection of point onto segment
+    dx = x2 - x1
+    dy = y2 - y1
+    if dx == 0 and dy == 0:
+        return ((x - x1) ** 2 + (y - y1) ** 2) ** 0.5
+    t = ((x - x1) * dx + (y - y1) * dy) / (dx * dx + dy * dy)
+    t = max(0.0, min(1.0, t))
+    proj_x = x1 + t * dx
+    proj_y = y1 + t * dy
+    return ((x - proj_x) ** 2 + (y - proj_y) ** 2) ** 0.5

--- a/tests/test_line_store.py
+++ b/tests/test_line_store.py
@@ -1,0 +1,171 @@
+"""Unit tests for :mod:`src.line_store`."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+import importlib.util
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "src" / "line_store.py"
+SPEC = importlib.util.spec_from_file_location("line_store", MODULE_PATH)
+assert SPEC and SPEC.loader
+line_store = importlib.util.module_from_spec(SPEC)
+import sys
+sys.modules[SPEC.name] = line_store
+SPEC.loader.exec_module(line_store)
+
+AddLine = line_store.AddLine
+Line = line_store.Line
+LineStore = line_store.LineStore
+Point = line_store.Point
+RemoveLines = line_store.RemoveLines
+SetSelection = line_store.SetSelection
+TokenOrder = line_store.TokenOrder
+UpdateText = line_store.UpdateText
+
+
+def _line(
+    id_: int,
+    baseline: List[Point],
+    text: str,
+    order_key: TokenOrder,
+    *,
+    selected: bool = False,
+    is_manual: bool = False,
+) -> Line:
+    min_x = int(min(pt[0] for pt in baseline))
+    min_y = int(min(pt[1] for pt in baseline))
+    max_x = int(max(pt[0] for pt in baseline)) + 1
+    max_y = int(max(pt[1] for pt in baseline)) + 1
+    return Line(
+        id=id_,
+        baseline=list(baseline),
+        bbox=(min_x, min_y, max_x, max_y),
+        text=text,
+        order_key=order_key,
+        selected=selected,
+        is_manual=is_manual,
+    )
+
+
+def test_set_lines_and_compose_text() -> None:
+    store = LineStore()
+    lines = [
+        _line(1, [(0, 0), (10, 0)], "alpha", (0, 0, 0, 0, 0)),
+        _line(2, [(0, 10), (10, 10)], "beta", (0, 0, 0, 0, 1)),
+    ]
+    store.set_lines(lines)
+
+    listed = store.list()
+    assert [line.id for line in listed] == [1, 2]
+    assert store.compose_text() == "alpha\nbeta"
+
+
+def test_add_line_assigns_id_and_bbox() -> None:
+    store = LineStore()
+    line_id = store.add_line([(5.0, 5.0), (15.0, 8.0)], is_manual=True)
+    listed = store.list()
+    assert line_id == 1
+    assert len(listed) == 1
+    line = listed[0]
+    assert line.id == line_id
+    assert line.bbox == (5, 5, 16, 9)
+    assert line.is_manual is True
+
+
+def test_selection_and_toggle() -> None:
+    store = LineStore()
+    store.set_lines([
+        _line(1, [(0, 0), (10, 0)], "alpha", (0, 0, 0, 0, 0)),
+        _line(2, [(0, 10), (10, 10)], "beta", (0, 0, 0, 0, 1)),
+    ])
+
+    store.select_only({2})
+    assert store.selection() == {2}
+    store.toggle(2)
+    assert store.selection() == set()
+    store.toggle(1)
+    assert store.selection() == {1}
+
+
+def test_remove_and_reinsert_via_command() -> None:
+    store = LineStore()
+    store.set_lines([
+        _line(1, [(0, 0), (10, 0)], "alpha", (0, 0, 0, 0, 0)),
+        _line(2, [(0, 10), (10, 10)], "beta", (0, 0, 0, 0, 1)),
+    ])
+    store.select_only({1, 2})
+
+    cmd = RemoveLines({1})
+    store.do(cmd)
+    assert [line.id for line in store.list()] == [2]
+    store.undo()
+    assert [line.id for line in store.list()] == [1, 2]
+    assert store.selection() == {1, 2}
+    store.redo()
+    assert [line.id for line in store.list()] == [2]
+
+
+def test_update_text_command_tracks_history() -> None:
+    store = LineStore()
+    store.set_lines([
+        _line(5, [(0, 0), (10, 0)], "", (0, 0, 0, 0, 0)),
+    ])
+
+    cmd = UpdateText(5, "hello")
+    store.do(cmd)
+    assert store.list()[0].text == "hello"
+    store.undo()
+    assert store.list()[0].text == ""
+
+
+def test_hit_test_and_bbox_intersection() -> None:
+    store = LineStore()
+    store.set_lines([
+        _line(1, [(0, 0), (10, 0)], "alpha", (0, 0, 0, 0, 0)),
+        _line(2, [(0, 10), (10, 10)], "beta", (0, 0, 0, 0, 1)),
+    ])
+
+    hit = store.hit_test(3, 1, tol=2.0)
+    assert hit == 1
+    hits = store.bbox_intersect((0, 5, 12, 12))
+    assert hits == {2}
+
+
+def test_add_line_command_round_trip() -> None:
+    store = LineStore()
+    cmd = AddLine([(0.0, 0.0), (5.0, 0.0)])
+    store.do(cmd)
+    assert len(store.list()) == 1
+    store.undo()
+    assert len(store.list()) == 0
+    store.redo()
+    assert len(store.list()) == 1
+
+
+def test_set_selection_command_additive() -> None:
+    store = LineStore()
+    store.set_lines([
+        _line(1, [(0, 0), (10, 0)], "alpha", (0, 0, 0, 0, 0)),
+        _line(2, [(0, 10), (10, 10)], "beta", (0, 0, 0, 0, 1)),
+    ])
+
+    cmd = SetSelection({1}, additive=False)
+    store.do(cmd)
+    assert store.selection() == {1}
+    store.undo()
+    assert store.selection() == set()
+
+    cmd_toggle = SetSelection({1, 2}, additive=True)
+    store.do(cmd_toggle)
+    assert store.selection() == {1, 2}
+    store.undo()
+    assert store.selection() == set()
+
+
+def test_add_line_requires_two_points() -> None:
+    store = LineStore()
+    with pytest.raises(ValueError):
+        store.add_line([(0.0, 0.0)], is_manual=True)


### PR DESCRIPTION
## Summary
- replace the Tk overlay boxes with a baseline-centric annotation UI powered by a new undoable LineStore
- integrate Kraken helpers, export pipelines for line crops and PAGE-XML, and extend the CLI to support the new engines and formats
- document Windows installation steps for Kraken and add unit tests covering LineStore operations

## Testing
- pytest tests/test_line_store.py

------
https://chatgpt.com/codex/tasks/task_e_68e1bf4aca84832b8cba32a25cc84563