### PR TITLE
Support Kraken segmentation API changes

### DIFF
--- a/src/kraken_adapter.py
+++ b/src/kraken_adapter.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 """Optional integration with Kraken (ketos) for segmentation and OCR."""
 
+import inspect
 import logging
 import shutil
 import subprocess
 from pathlib import Path
+from types import ModuleType
 from typing import List, Optional, Tuple
 
 from PIL import Image
@@ -30,6 +32,64 @@ def _require_kraken() -> None:
         )
 
 
+def _explain_import_error(exc: ImportError, previous_exc: ImportError | None = None) -> str:
+    """Return a user-facing explanation for Kraken import errors."""
+
+    message = str(exc)
+    if "kraken.blla is not a package" in message or "'kraken' is not a package" in message:
+        return (
+            "This Kraken installation no longer exposes the legacy 'kraken.blla' module. "
+            "Recent releases moved the segmentation API to 'kraken.lib.segmentation'. "
+            "Upgrade Standup-OCR or reinstall Kraken with 'pip install -U kraken[serve]' "
+            "to ensure the new module is available."
+        )
+
+    if previous_exc is not None:
+        previous_name = getattr(previous_exc, "name", "")
+        if previous_name == "kraken.lib.segmentation":
+            return (
+                "Kraken's modern segmentation API ('kraken.lib.segmentation') could not "
+                "be imported, and the legacy fallback also failed. Upgrade Kraken with "
+                "'pip install -U kraken[serve]' to obtain a compatible release."
+            )
+
+    if "not a package" in message:
+        return (
+            "Kraken could not be imported because another module named 'kraken' "
+            "is shadowing the official library. Rename or remove the conflicting "
+            "module (for example a local 'kraken.py' file) and reinstall the "
+            "package with 'pip install -U kraken[serve]'."
+        )
+
+    missing = getattr(exc, "name", "")
+    if missing in {"kraken", "kraken.blla", "kraken.lib.segmentation"}:
+        return (
+            "Kraken's Python API is unavailable. Ensure it is installed in the "
+            "current environment by running 'pip install -U kraken[serve]'."
+        )
+
+    return f"Kraken is installed but failed to load its segmentation API ({message})."
+
+
+def _load_segmentation_module() -> ModuleType:
+    """Load Kraken's segmentation module with support for multiple versions."""
+
+    lib_exc: ImportError | None = None
+    try:
+        from kraken.lib import segmentation as segmentation_mod  # type: ignore
+
+        return segmentation_mod
+    except ImportError as exc:
+        lib_exc = exc
+
+    try:
+        from kraken import blla as segmentation_mod  # type: ignore
+
+        return segmentation_mod
+    except ImportError as exc:
+        raise RuntimeError(_explain_import_error(exc, lib_exc)) from exc
+
+
 def segment_lines(image_path: Path, out_pagexml: Optional[Path] = None) -> List[List[Tuple[float, float]]]:
     """Run Kraken's baseline segmenter and return a list of baselines.
 
@@ -40,13 +100,39 @@ def segment_lines(image_path: Path, out_pagexml: Optional[Path] = None) -> List[
 
     _require_kraken()
     try:
-        from kraken import blla  # type: ignore
+        segmentation_module = _load_segmentation_module()
+    except RuntimeError:
+        raise
     except Exception as exc:  # pragma: no cover - only triggered when API fails
-        raise RuntimeError("Kraken is installed but the baseline API is unavailable") from exc
+        raise RuntimeError("Kraken is installed but the segmentation API is unavailable") from exc
 
     with Image.open(image_path) as image:
+        img = image.convert("L")
         try:
-            segmentation = blla.segment(image.convert("L"))  # type: ignore[attr-defined]
+            if hasattr(segmentation_module, "segment"):
+                segment_fn = getattr(segmentation_module, "segment")
+                kwargs = {}
+                signature = inspect.signature(segment_fn)
+                if "text_direction" in signature.parameters:
+                    kwargs["text_direction"] = "ltr"
+                if "script" in signature.parameters:
+                    kwargs["script"] = "latin"
+                if "model" in signature.parameters:
+                    kwargs["model"] = None
+                segmentation = segment_fn(img, **kwargs)
+            elif hasattr(segmentation_module, "segment_image"):
+                segment_fn = getattr(segmentation_module, "segment_image")
+                kwargs = {}
+                signature = inspect.signature(segment_fn)
+                if "model" in signature.parameters:
+                    kwargs["model"] = None
+                segmentation = segment_fn(img, **kwargs)
+            else:  # pragma: no cover - defensive
+                raise RuntimeError(
+                    "Unsupported Kraken segmentation API: expected 'segment' or 'segment_image'."
+                )
+        except RuntimeError:
+            raise
         except Exception as exc:  # pragma: no cover - segmentation errors only at runtime
             raise RuntimeError(f"Kraken segmentation failed: {exc}") from exc
 


### PR DESCRIPTION
## Summary
- load Kraken's segmentation module via `kraken.lib.segmentation` with a fallback to the legacy `kraken.blla`
- adapt segmentation invocation to work with both modern `segment` and legacy `segment_image` call signatures
- update import guidance to describe the Kraken API relocation instead of implying a missing paid component

## Testing
- pytest *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68e43b2565c0832b89e1767131b064dd